### PR TITLE
grub2: fix out-of-memory error during initrd

### DIFF
--- a/SPECS/grub2/0119-Fix-4GB-memory-be-filtered-out-by-filter_memory_map.patch
+++ b/SPECS/grub2/0119-Fix-4GB-memory-be-filtered-out-by-filter_memory_map.patch
@@ -1,0 +1,29 @@
+From: Jeremy Szu <jeremy.szu@canonical.com>
+Date: Wed, 29 Jun 2022 07:36:17 +0800
+Subject: Fix > 4GB memory be filtered out by filter_memory_map()
+
+If the size of initramfs grows bigger, then grub will probably not able
+to load initramfs (LP: #1842320).
+
+Although kernel_alloc() support > 4GB for kernel/initramfs, the
+retrieved memory map from EFI_BOOT_SERVICES.GetMemoryMap() has been
+limited with 2 GB. (0x7fffffff)
+Remove the limitation to align the GRUB_EFI_MAX_USABLE_ADDRESS to make
+the > 4 GB memory allocation works.
+---
+ include/grub/x86_64/efi/memory.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/grub/x86_64/efi/memory.h b/include/grub/x86_64/efi/memory.h
+index e81cfb3..547e3f8 100644
+--- a/include/grub/x86_64/efi/memory.h
++++ b/include/grub/x86_64/efi/memory.h
+@@ -3,7 +3,7 @@
+ 
+ #if defined (__code_model_large__)
+ #define GRUB_EFI_MAX_USABLE_ADDRESS __UINTPTR_MAX__
+-#define GRUB_EFI_MAX_ALLOCATION_ADDRESS 0x7fffffff
++#define GRUB_EFI_MAX_ALLOCATION_ADDRESS GRUB_EFI_MAX_USABLE_ADDRESS
+ #else
+ #define GRUB_EFI_MAX_USABLE_ADDRESS 0x7fffffff
+ #define GRUB_EFI_MAX_ALLOCATION_ADDRESS GRUB_EFI_MAX_USABLE_ADDRESS

--- a/SPECS/grub2/grub2.spec
+++ b/SPECS/grub2/grub2.spec
@@ -7,10 +7,10 @@
 Summary:        GRand Unified Bootloader
 Name:           grub2
 Version:        2.06
-Release:        22%{?dist}
+Release:        23%{?dist}
 License:        GPLv3+
-Vendor:         Microsoft Corporation
-Distribution:   Azure Linux
+Vendor:         Intel Corporation
+Distribution:   Edge Microvisor Toolkit
 Group:          Applications/System
 URL:            https://www.gnu.org/software/grub
 Source0:        https://git.savannah.gnu.org/cgit/grub.git/snapshot/grub-%{version}.tar.gz
@@ -39,6 +39,7 @@ Patch0115:      0115-x86-efi-Use-bounce-buffers-for-reading-to-addresses-.patch
 Patch0116:      0116-x86-efi-Re-arrange-grub_cmd_linux-a-little-bit.patch
 Patch0117:      0117-x86-efi-Make-our-own-allocator-for-kernel-stuff.patch
 Patch0118:      0118-x86-efi-Allow-initrd-params-cmdline-allocations-abov.patch
+Patch0119:      0119-Fix-4GB-memory-be-filtered-out-by-filter_memory_map.patch
 Patch0148:      0148-efi-Set-image-base-address-before-jumping-to-the-PE-.patch
 Patch0149:      0149-tpm-Don-t-propagate-TPM-measurement-errors-to-the-ve.patch
 Patch0150:      0150-x86-efi-Reduce-maximum-bounce-buffer-size-to-16-MiB.patch
@@ -433,6 +434,9 @@ cp $GRUB_PXE_MODULE_SOURCE $EFI_BOOT_DIR/$GRUB_PXE_MODULE_NAME
 %config(noreplace) %{_sysconfdir}/grub.d/41_custom
 
 %changelog
+* Mon Apr 07 2025 Mun Chun Yep <mun.chun.yep@intel.com> - 2.06-23
+- Add patch to remove the 2GB limitation in memory map.
+
 * Sun Nov 10 2024 Chris Co <chrco@microsoft.com> - 2.06-22
 - Set efidir location to BOOT for eventual use in changing to "azurelinux"
 - Bump release to also force signing with the new Azure Linux secure boot key


### PR DESCRIPTION
Add patch to remove the 2GB limitation in memory map.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->

During ISO installation, an "out of memory" error occurred when grub tries to load initrd image.
Due to the 2GB limitation in memory map, grub was not able to find enough memory space allocation for initrd image.
This PR ports a workaround patch from Canonical [Launchpad bug](https://bugs.launchpad.net/oem-priority/+bug/1842320) to remove the 2GB limitation of memory map in grub.

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

No

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Tested in RPL platform, with ISO engineering build. 
Flashed the ISO image into a USB drive and boot up from there. 
grub able to allocate sufficient memory space for initrd image, before passing off to kenel mount.
Observation: no "out of memory" error.