### PR TITLE
caddy: fix CVE-2024-45339

### DIFF
--- a/SPECS/caddy/CVE-2024-45339.patch
+++ b/SPECS/caddy/CVE-2024-45339.patch
@@ -1,0 +1,120 @@
+From afd4339ec8682b92eb6bcc870d138106ffd5f58d Mon Sep 17 00:00:00 2001
+From: kavyasree <kkaitepalli@microsoft.com>
+Date: Fri, 31 Jan 2025 21:16:51 +0530
+Subject: [PATCH] Patch CVE-2024-45339
+
+Reference: https://github.com/golang/glog/pull/74
+
+---
+ vendor/github.com/golang/glog/glog_file.go | 60 ++++++++++++++++------
+ 1 file changed, 44 insertions(+), 16 deletions(-)
+
+diff --git a/vendor/github.com/golang/glog/glog_file.go b/vendor/github.com/golang/glog/glog_file.go
+index e7d125c..6d239fa 100644
+--- a/vendor/github.com/golang/glog/glog_file.go
++++ b/vendor/github.com/golang/glog/glog_file.go
+@@ -118,32 +118,53 @@ var onceLogDirs sync.Once
+ // contains tag ("INFO", "FATAL", etc.) and t.  If the file is created
+ // successfully, create also attempts to update the symlink for that tag, ignoring
+ // errors.
+-func create(tag string, t time.Time) (f *os.File, filename string, err error) {
++func create(tag string, t time.Time, dir string) (f *os.File, filename string, err error) {
++	if dir != "" {
++		f, name, err := createInDir(dir, tag, t)
++		if err == nil {
++			return f, name, err
++		}
++		return nil, "", fmt.Errorf("log: cannot create log: %v", err)
++	}
++
+ 	onceLogDirs.Do(createLogDirs)
+ 	if len(logDirs) == 0 {
+ 		return nil, "", errors.New("log: no log dirs")
+ 	}
+-	name, link := logName(tag, t)
+ 	var lastErr error
+ 	for _, dir := range logDirs {
+-		fname := filepath.Join(dir, name)
+-		f, err := os.Create(fname)
++		f, name, err := createInDir(dir, tag, t)
+ 		if err == nil {
+-			symlink := filepath.Join(dir, link)
+-			os.Remove(symlink)        // ignore err
+-			os.Symlink(name, symlink) // ignore err
+-			if *logLink != "" {
+-				lsymlink := filepath.Join(*logLink, link)
+-				os.Remove(lsymlink)         // ignore err
+-				os.Symlink(fname, lsymlink) // ignore err
+-			}
+-			return f, fname, nil
++			return f, name, err
+ 		}
+ 		lastErr = err
+ 	}
+ 	return nil, "", fmt.Errorf("log: cannot create log: %v", lastErr)
+ }
+ 
++func createInDir(dir, tag string, t time.Time) (f *os.File, name string, err error) {
++	name, link := logName(tag, t)
++	fname := filepath.Join(dir, name)
++	// O_EXCL is important here, as it prevents a vulnerability. The general idea is that logs often
++	// live in an insecure directory (like /tmp), so an unprivileged attacker could create fname in
++	// advance as a symlink to a file the logging process can access, but the attacker cannot. O_EXCL
++	// fails the open if it already exists, thus prevent our this code from opening the existing file
++	// the attacker points us to.
++	f, err = os.OpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
++	if err == nil {
++		symlink := filepath.Join(dir, link)
++		os.Remove(symlink)        // ignore err
++		os.Symlink(name, symlink) // ignore err
++		if *logLink != "" {
++			lsymlink := filepath.Join(*logLink, link)
++			os.Remove(lsymlink)         // ignore err
++			os.Symlink(fname, lsymlink) // ignore err
++		}
++		return f, fname, nil
++	}
++	return nil, "", err
++}
++
+ // flushSyncWriter is the interface satisfied by logging destinations.
+ type flushSyncWriter interface {
+ 	Flush() error
+@@ -247,6 +268,7 @@ type syncBuffer struct {
+ 	names  []string
+ 	sev    logsink.Severity
+ 	nbytes uint64 // The number of bytes written to this file
++	madeAt time.Time
+ }
+ 
+ func (sb *syncBuffer) Sync() error {
+@@ -254,9 +276,14 @@ func (sb *syncBuffer) Sync() error {
+ }
+ 
+ func (sb *syncBuffer) Write(p []byte) (n int, err error) {
++	// Rotate the file if it is too large, but ensure we only do so,
++	// if rotate doesn't create a conflicting filename.
+ 	if sb.nbytes+uint64(len(p)) >= MaxSize {
+-		if err := sb.rotateFile(time.Now()); err != nil {
+-			return 0, err
++		now := timeNow()
++		if now.After(sb.madeAt.Add(1*time.Second)) || now.Second() != sb.madeAt.Second() {
++			if err := sb.rotateFile(now); err != nil {
++				return 0, err
++			}
+ 		}
+ 	}
+ 	n, err = sb.Writer.Write(p)
+@@ -274,7 +301,8 @@ const footer = "\nCONTINUED IN NEXT FILE\n"
+ func (sb *syncBuffer) rotateFile(now time.Time) error {
+ 	var err error
+ 	pn := "<none>"
+-	file, name, err := create(sb.sev.String(), now)
++	file, name, err := create(sb.sev.String(), now, "")
++	sb.madeAt = now
+ 
+ 	if sb.file != nil {
+ 		// The current log file becomes the previous log at the end of
+-- 
+2.34.1
+

--- a/SPECS/caddy/caddy.spec
+++ b/SPECS/caddy/caddy.spec
@@ -3,7 +3,7 @@
 Summary:        Web server with automatic HTTPS
 Name:           caddy
 Version:        2.9.1
-Release:        9%{?dist}
+Release:        10%{?dist}
 Distribution:   Edge Microvisor Toolkit
 Vendor:         Intel Corporation
 # main source code is Apache-2.0
@@ -29,6 +29,7 @@ Source31:       poweredby-black.png
 # downstream only patch to disable commands that can alter the binary
 Patch1:         0001-Disable-commands-that-can-alter-the-binary.patch
 Patch2:         CVE-2025-22869.patch
+Patch3:         CVE-2024-45339.patch
 BuildRequires:  go-rpm-macros
 # https://github.com/caddyserver/caddy/commit/2028da4e74cd41f0f7f94222c6599da1a371d4b8
 BuildRequires:  golang >= 1.22.3
@@ -458,6 +459,9 @@ fi
 %attr(0755,caddy,caddy) %{_sysconfdir}/edge-node/node/confs/post-caddy.sh
 
 %changelog
+* Wed Apr 09 2025 Tan Jia Yong <jia.yong.tan@intel.com> - 2.9.1-10
+- Include patch for CVE-2024-45339
+
 * Mon Apr 07 2025 kintali Jayanth <kintalix.jayanth@intel.com> - 2.9.1-9
 - Resolve in CVE-2025-22869.patch
 


### PR DESCRIPTION
This patch is taken from Azure Linux.
This patch had been tested to build with caddy package.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->A vulnerability in github.com/golang/glog allows attackers to exploit log file paths in writable directories by using symbolic links to overwrite sensitive files. glog now exits with status code 2 if the log file already exists.


Fixes # (issue)
CVE-2024-45339

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->
No
#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
The package is built with the patch applied.