### PR TITLE
iso: fix media ejection in text-based finishview

### DIFF
--- a/toolkit/tools/imagegen/attendedinstaller/views/finishview/finishview.go
+++ b/toolkit/tools/imagegen/attendedinstaller/views/finishview/finishview.go
@@ -15,6 +15,7 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/attendedinstaller/uiutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/configuration"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
 )
 
 // UI constants.
@@ -136,6 +137,14 @@ func (fv *FinishView) OnShow() {
 	// since the installation time is not known during Initialize().
 	// Force a focus change as the flex box has just been initialized in updateTextSize().
 	fv.app.SetFocus(fv.centeredFlex)
+
+	const squashErrors = false
+	program := "eject"
+	commandArgs := []string{
+		"--cdrom",
+		"--force",
+	}
+	shell.ExecuteLive(squashErrors, program, commandArgs...)
 }
 
 func (fv *FinishView) updateTextSize() {


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
In text-based installation mode, removing the installation media in the finishview causes boot-up errors due to incomplete processes.

This commit adds an eject operation in the finishview to complete pending write operations and properly close the file system, allowing the user to remove the installation media in finishview.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->
No
#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
