### PR TITLE
[Tink] initramfs boot to console with tmpfs root

### DIFF
--- a/SPECS/dracut/90tmpfsroot/tmpfsroot-module-setup.sh
+++ b/SPECS/dracut/90tmpfsroot/tmpfsroot-module-setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright (c) Intel Corporation.
+# Licensed under the MIT License.
+
+check() {
+    require_binaries tar || return 1
+    return 0
+}
+
+depends() {
+    return 0
+}
+
+install() {
+    inst_hook mount 90 "$moddir/tmpfsroot-mount.sh"
+}

--- a/SPECS/dracut/90tmpfsroot/tmpfsroot-mount.sh
+++ b/SPECS/dracut/90tmpfsroot/tmpfsroot-mount.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) Intel Corporation.
+# Licensed under the MIT License.
+
+info "mount tmpfs for root"
+if ! mount -t tmpfs -o size=1G tmpfs $NEWROOT; then
+  warn "Failed to mount tmpfs on $NEWROOT"
+  die
+fi
+
+cd $NEWROOT
+
+if [[ -f /rootfs.tar.gz ]]; then
+  info "extract rootfs.tar.gz to $NEWROOT"
+  tar -xvf /rootfs.tar.gz -C $NEWROOT
+else
+  warn "no rootfs.tar.gz found"
+  die
+fi
+
+info "rootfs on tmpfs complete"

--- a/SPECS/dracut/dracut.signatures.json
+++ b/SPECS/dracut/dracut.signatures.json
@@ -12,6 +12,8 @@
   "dracut-102.tar.gz": "601b175cbf4d2ee902bb7bda3af8826ae2ca060c1af880f6da5a833413f4ec70",
   "lgpl-2.1.txt": "dc626520dcd53a22f727af3ee42c770e56c97a64fe3adb063799d8ab032fe551",
   "megaraid.conf": "914824cdbe0c525b71efa05a75e453335b0068beb8bc28bef2a5866d74bf7dd4",
+  "tmpfsroot-module-setup.sh": "d1e2d512a3769fb70f7726b1899f89950d5bfc2199e8cde5df44adebd740006f",
+  "tmpfsroot-mount.sh": "884c4c9a17118229dfbb40ec9a4a23d307c12349dbf19adc1a2d8640c2f77fd0",
   "module-setup.sh": "8f5a0d3cc393d78bcb523b0d53c578d2767d688f00e84b525355bbb31d753da4",
   "overlayfs-mount.sh": "28f47c107a4435c5153bdb5b2f92f20b7a75bf3932216635ee810875c27dd55b"
  }

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -4,7 +4,7 @@
 Summary:        dracut to create initramfs
 Name:           dracut
 Version:        102
-Release:        12%{?dist}
+Release:        13%{?dist}
 # The entire source code is GPLv2+
 # except install/* which is LGPLv2+
 License:        GPLv2+ AND LGPLv2+
@@ -31,6 +31,8 @@ Source11:       50-noxattr.conf
 Source12:       90livenet/azl-liveos-artifacts-download.service
 Source13:       90livenet/azl-liveos-artifacts-download.sh
 Source14:       90overlayfs/azl-configure-selinux.sh
+Source15:       90tmpfsroot/tmpfsroot-module-setup.sh
+Source16:       90tmpfsroot/tmpfsroot-mount.sh
 
 # allow-liveos-overlay-no-user-confirmation-prompt.patch has been introduced by
 # the Azure Linux team to allow skipping the user confirmation prompt during
@@ -156,6 +158,13 @@ Requires:       %{name} = %{version}-%{release}
 %description systemd-cryptsetup
 This package contains dracut module needed to build an initramfs with systemd-cryptsetup enabled.
 
+%package tmpfsroot
+Summary:        dracut module to support root on tmpfs
+Requires:       %{name} = %{version}-%{release}
+
+%description tmpfsroot
+This package contains dracut module root on tmpfs.
+
 %package virtio
 Summary:        dracut configuration needed to build an initramfs with virtio guest drivers
 Requires:       %{name} = %{version}-%{release}
@@ -231,6 +240,10 @@ mkdir -p %{buildroot}%{dracutlibdir}/modules.d/20overlayfs/
 install -p -m 0755 %{SOURCE4} %{buildroot}%{dracutlibdir}/modules.d/20overlayfs/
 install -p -m 0755 %{SOURCE5} %{buildroot}%{dracutlibdir}/modules.d/20overlayfs/
 
+mkdir -p %{buildroot}%{dracutlibdir}/modules.d/90tmpfsroot/
+install -p -m 0755 %{SOURCE15} %{buildroot}%{dracutlibdir}/modules.d/90tmpfsroot/module-setup.sh
+install -p -m 0755 %{SOURCE16} %{buildroot}%{dracutlibdir}/modules.d/90tmpfsroot/
+
 touch %{buildroot}%{_var}/opt/%{name}/log/%{name}.log
 ln -srv %{buildroot}%{_var}/opt/%{name}/log/%{name}.log %{buildroot}%{_var}/log/
 
@@ -251,6 +264,7 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %exclude %{_libdir}/kernel
 %exclude %{dracutlibdir}/modules.d/20overlayfs
 %exclude %{dracutlibdir}/modules.d/90systemd-cryptsetup
+%exclude %{dracutlibdir}/modules.d/90tmpfsroot
 %{_libdir}/%{name}/%{name}-init.sh
 %{_datadir}/pkgconfig/%{name}.pc
 %{dracutlibdir}/%{name}-functions.sh
@@ -319,6 +333,10 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %dir %{dracutlibdir}/modules.d/90systemd-cryptsetup
 %{dracutlibdir}/modules.d/90systemd-cryptsetup/*
 
+%files tmpfsroot
+%dir %{dracutlibdir}/modules.d/90tmpfsroot
+%{dracutlibdir}/modules.d/90tmpfsroot/*
+
 %files virtio
 %defattr(-,root,root,0755)
 %{_sysconfdir}/dracut.conf.d/00-virtio.conf
@@ -337,6 +355,9 @@ ln -srv %{buildroot}%{_bindir}/%{name} %{buildroot}%{_sbindir}/%{name}
 %dir %{_sharedstatedir}/%{name}/overlay
 
 %changelog
+* Fri May 16 2025 Swee Yee Fonn <swee.yee.fonn@intel.com> - 102-13
+- Add tmpfsroot dracut module
+
 * Thu Apr 28 2025 Ranjan Dutta <ranjan.dutta@intel.com> - 102-12
 - merge from Azure Linux tag 3.0.20250423-3.0
 - Add fix for systemd-cryptsetup module to be included in initramfs when needed

--- a/toolkit/imageconfigs/edge-image-tink.json
+++ b/toolkit/imageconfigs/edge-image-tink.json
@@ -6,7 +6,7 @@
             "Artifacts": [
                 {
                     "Name": "edge-readonly-tink",
-                    "Compression": "tar.gz"
+                    "Type": "tar.gz"
                 }
             ]
         }
@@ -37,13 +37,17 @@
             "FinalizeImageScripts": [
                 {
                     "Path": "scripts/cleanup.sh"
+                },
+                {
+                    "Path": "scripts/setup-tink-image.sh"
                 }
             ],
             "KernelCommandLine": {
-                "ExtraCommandLine": "quiet splash"
+                "ExtraCommandLine": "root=tmpfs rootflags=size=1G,mode=0755 rd.skipfsck noresume quiet splash"
             },
-            "Hostname": "EdgeMicrovisorToolkitTink",
+            "Hostname": "EMT-tink",
             "DisableRpmDocs": true,
+            "RemoveRpmDb": true,
             "Users": [
                 {
                     "Name": "root",

--- a/toolkit/imageconfigs/packagelists/tink-packages.json
+++ b/toolkit/imageconfigs/packagelists/tink-packages.json
@@ -1,5 +1,7 @@
 {
     "packages": [
+        "dracut-tmpfsroot",
+        "tar",
         "fluent-bit",
         "caddy",
         "rng-tools",

--- a/toolkit/imageconfigs/scripts/generate-tink-initramfs.sh
+++ b/toolkit/imageconfigs/scripts/generate-tink-initramfs.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Copyright (c) Intel Corporation.
+# Licensed under the MIT License.
+
+set -e
+#set -x
+
+pprefix="Tink"
+
+function generate_images() {
+    if [[ $# -eq 2 ]]; then
+        fpath=$(realpath "$1")
+        if [[ $? -ne 0 || ! -f "$fpath" || ! -s "$fpath" ]]; then
+            echo "Error: $fpath invalid/zero sized" | tee -a "$LOG_FILE"
+            exit 255
+        fi
+    else
+        echo "Error: Invalid param to ${FUNCNAME[0]}"
+        exit 255
+    fi
+    local arfname="rootfs"
+    cp "$1" "/tmp/$arfname.tar.gz"
+    local outputdir="$2"
+
+    tar -xvf "/tmp/$arfname.tar.gz" -C "$outputdir" --strip-components=2 --wildcards ./boot/vmlinuz-*.emt3 ./boot/initramfs-*.emt3.img
+    gunzip -f "/tmp/$arfname.tar.gz"
+    tar -vf "/tmp/$arfname.tar" --delete ./tmp ./boot
+    gzip -f "/tmp/$arfname.tar"
+    #cp "/tmp/$arfname.tar.gz" "$outputdir"
+
+    ramfs=$(find $outputdir -type f -name initramfs*img -printf '%f\n')
+    echo "pprefix: Original $ramfs $(sync;du -h $outputdir/$ramfs)"
+    # unzip initramfs
+    mkdir -p /tmp/initramfs
+    cd /tmp/initramfs
+    echo "pprefix: inside $(pwd)"
+    echo "pprefix: unziping initial initramfs for repack"
+    gunzip -c -k "$outputdir/$ramfs" | cpio -idmv --no-absolute-filenames
+    #echo "pprefix: free space $(df -h)"
+
+    cp "/tmp/$arfname.tar.gz" /tmp/initramfs/
+    find . | cpio -o -H newc | gzip > "$outputdir/$ramfs"
+    cd -
+
+    echo "pprefix: $(sync;du -h $outputdir/$ramfs)"
+    rm -rf /tmp/initramfs
+    chmod 0666 $outputdir/vmlinuz-*.emt3 $outputdir/initramfs-*.emt3.img
+}
+
+# inputs
+emtfile=""
+odir=""
+
+function parse_arg() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -h|-\?|--help)
+                printf "Usage: %s [-h] <-f emt_tar_gz_file> [-o output_dir]\n" "$(basename "${BASH_SOURCE[0]}")"
+                exit
+                ;;
+
+            -f)
+                emtfile=$(realpath "$2")
+                if [[ ! -f "$emtfile" || $(tar -tvf "$emtfile" &> /dev/null) ]]; then
+                    echo "Error: $2 invalid tar.gz file"
+                    return 255
+                fi
+                echo "Info: input file $emtfile"
+                shift
+                ;;
+
+            -o)
+                odir=$(realpath "$2")
+                if [[ ! -d "$odir" ]]; then
+                    echo "Error: $2 invalid output directory"
+                    return 255
+                fi
+                echo "Info: output directory $odir"
+                shift
+                ;;
+
+            -?*)
+                echo "Error: Invalid option: $1"
+                show_help
+                return 255
+                ;;
+            *)
+                echo "Error: Unknown option: $1"
+                return 255
+                ;;
+        esac
+        shift
+    done
+}
+
+#-------------    main processes    -------------
+trap 'echo "Error $(realpath ${BASH_SOURCE[0]}) line ${LINENO}: $BASH_COMMAND"' ERR
+
+parse_arg "$@" || exit 255
+if [[ -z "$odir" ]]; then
+    odir=$(pwd)
+fi
+generate_images "$emtfile" "$odir" || exit 255

--- a/toolkit/imageconfigs/scripts/setup-tink-image.sh
+++ b/toolkit/imageconfigs/scripts/setup-tink-image.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Copyright (c) Intel Corporation.
+# Licensed under the MIT License.
+
+set -e
+set -x
+
+pprefix="Tink"
+
+# services
+systemctl disable systemd-homed.service
+systemctl enable caddy.service
+systemctl enable fluent-bit.service
+mkdir -p /etc/fluent-bit
+if [ ! -f /etc/fluent-bit/fluent-bit.conf ]; then
+  touch /etc/fluent-bit/fluent-bit.conf
+fi
+echo "$pprefix: fstab contents $(cat /etc/fstab)"
+echo 'tmpfs   /   tmpfs   defaults,size=1G   0   0' > /etc/fstab
+echo "$pprefix: $(du -h /usr/share)"
+find /usr/share -type f \
+  ! -path "/usr/share/terminfo/v/vt100" \
+  ! -path "/usr/share/terminfo/v/vt220" \
+  ! -path "/usr/share/keymaps/include/*" \
+  ! -path "/usr/share/keymaps/i386/include/*" \
+  ! -path "/usr/share/keymaps/i386/qwerty/us.map.gz" \
+  ! -path "/usr/share/consolefonts/lat9w-16*" \
+  ! -path "/usr/share/dbus-1/system.conf" \
+  ! -path "/usr/share/caddy/*" \
+  ! -path "/usr/share/pki/*" \
+  -exec rm -f {} +
+echo "$pprefix: reduced $(du -h /usr/share)"
+
+ramfs=$(find /boot -type f -name initramfs*img -printf '%f\n')
+# unzip initramfs
+mkdir /tmp/initramfs
+cd /tmp/initramfs
+echo "$pprefix: inside $(pwd)"
+echo "$pprefix: unziping initial initramfs for repack"
+gunzip -c -k /boot/$ramfs | cpio -idmv --no-absolute-filenames
+echo "$pprefix: free space $(df -h)"
+
+cd /tmp/initramfs
+echo "$pprefix: inside $(pwd)"
+echo "$pprefix: after copy $(du -h /tmp/initramfs)"
+echo "$pprefix: check cmdline.d $(ls etc/cmdline.d)"
+echo "$pprefix: check cmdline.d contents $(cat etc/cmdline.d/95root-dev.conf)"
+echo 'root=tmpfs rootflags=size=1G,mode=0755' > etc/cmdline.d/95root-dev.conf
+echo "$pprefix: check cmdline.d contents after edit $(cat etc/cmdline.d/95root-dev.conf)"
+echo "$pprefix: before rm devexist* $(ls -al var/lib/dracut/hooks/initqueue/finished/)"
+rm -f var/lib/dracut/hooks/initqueue/finished/devexists*
+echo "$pprefix: after rm devexist* $(ls -al var/lib/dracut/hooks/initqueue/finished/)"
+echo "$pprefix: before rm wants $(ls -al etc/systemd/system/initrd.target.wants/)"
+rm -rf etc/systemd/system/initrd.target.wants/dev-disk-b*
+echo "$pprefix: after rm wants $(ls etc/systemd/system/initrd.target.wants/)"
+echo "$pprefix: before rm disk service $(ls -al etc/systemd/system/dev-disk-b*)"
+rm -rf etc/systemd/system/dev-disk-b*
+echo "$pprefix: after rm disk service $(ls -al etc/systemd/system/)"
+echo "$(find . -iname dev-disk*)"
+# copy tar required for uncompressing rootfs archive
+echo "$pprefix: before copy tar $(find . -iname tar)"
+cp /usr/bin/tar usr/bin
+echo "$pprefix: after copy tar $(find . -iname tar)"
+#mv /rootfs.tar.gz /tmp/initramfs/
+find . | cpio -o -H newc | gzip > /boot/$ramfs
+cd -
+
+echo "$pprefix: $(ls -l /boot/$ramfs)"
+rm -rf /tmp/initramfs


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Add dracut module for boot to console with root in tmpfs.
Generate Tink initramfs image in build which is able to
boot to console with just initramfs/vmlinuz image.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Able to boot to console with vmlinuz/initramfs images extracted from built edge-image-tink.tar.gz