### PR TITLE
systemd: disable tcp timestamps.

### DIFF
--- a/SPECS/systemd/99-tcp-timestamps.conf
+++ b/SPECS/systemd/99-tcp-timestamps.conf
@@ -1,0 +1,3 @@
+# disable TCP timestamps option in the TCP header.
+# The value 0 disables timestamps and 1 enables timestamps.
+net.ipv4.tcp_timestamps = 0

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -11,6 +11,7 @@
   "99-yama-ptrace.conf": "5a4876d61267e5748b4765923a8d169136fc5c161d7f363250dc24849c7cfe80",
   "99-net-core-bpf-jit-harden.conf": "5eb31e2e240cab5f57217be2e9460af2cb989d9e3fc4c7c7b50cbba536d8e7f2",
   "99-kernel.conf": "0ddcedb57a5ec3be92ffd6ea88b2fd4e1ab16e8fee0fda58727757c77ad688cb",
+  "99-tcp-timestamps.conf": "698d35fe8117ffd8afb47a25aae9cc0cc7b3424c837c7eec27f77a9dea009972",
   "macros.sysusers": "b7c3941912208657b68a5890b8e320d626a6bc17290a223b46071e251b240160",
   "split-files.py": "ff2ace09f116028299f75ab1f81ca467a6dc4e7ad38c27c22d2e8dd1229ad0dd",
   "sysctl.conf.README": "51d16ee2e7eef12dd42e924af6b835861e8b79d11921ba0418d7d0aec7a2a93b",

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        27%{?dist}
+Release:        28%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -109,6 +109,7 @@ Source27:       99-magic-sysrq.conf
 Source28:       99-yama-ptrace.conf
 Source29:       99-net-core-bpf-jit-harden.conf
 Source30:       99-kernel.conf
+Source31:       99-tcp-timestamps.conf
 
 %if 0
 GIT_DIR=../../src/systemd/.git git format-patch-ab --no-signature -M -N v235..v235-stable
@@ -882,6 +883,9 @@ install -Dm0644 10-timeout-abort.conf.user %{buildroot}%{user_unit_dir}/service.
 # https://fedoraproject.org/wiki/Changes/IncreaseVmMaxMapCount
 install -Dm0644 -t %{buildroot}%{_prefix}/lib/sysctl.d/ %{SOURCE17}
 
+# Install TCP timestamp setting
+install -Dm0644 -t %{buildroot}%{_prefix}/lib/sysctl.d/ %{SOURCE31}
+
 %if 0%{?emt}
 install -Dm0644 -t %{buildroot}%{_prefix}/lib/sysctl.d/ %{SOURCE18}
 install -Dm0644 -t %{buildroot}%{_prefix}/lib/sysctl.d/ %{SOURCE26}
@@ -1233,6 +1237,9 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Tue May 20 2025 Basavaraj unniche <basavarajx.unniche@intel.com> - 255-28
+- Add kernel command to disable TCP timestamps.
+
 * Fri Mar 07 2025 Ranjan Dutta <ranjan.dutta@intel.com> - 255-27
 - Bump up the version on merge frm AZL tag 3.0.20250206-3.0
 - adding patch for enhancing DNSSEC signature validation integrity


### PR DESCRIPTION
  This setting allows to disable TCP timestamps on host.
  OS user can use 'sysctl net.ipv4.tcp_timestamps' command to
  check the setting.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
Added kernel command in systemd service to disable TCP timestamps.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
No.

#### How Has This Been Tested? <!-- REQUIRED -->
First systemd rpm has built with modified systemd spec file.
With above systemd binaries, created iso and installed on system. verified as below.
![image](https://github.com/user-attachments/assets/bc6f768e-f331-4134-9256-700190aa42fb)


