### PR TITLE
Systemd: changed value of kernel.yama.ptrace_scope to 0

### DIFF
--- a/SPECS/systemd/99-yama-ptrace.conf
+++ b/SPECS/systemd/99-yama-ptrace.conf
@@ -39,4 +39,4 @@
 # for change the setting temporarily, or copy this file to
 # /etc/sysctl.d/20-yama-ptrace.conf to set it for future boots.
 
-kernel.yama.ptrace_scope = 3
+kernel.yama.ptrace_scope = 0

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -8,7 +8,7 @@
   "98-default-mac-none.link": "11efa1aee1d52e74b3ca5d1db903e9e1f3ca5e07498c25ea13e40452e2430e1a",
   "99-default-suid-dumpable.conf": "40e2a0608ec9fb5ea69e2b6bbcf310b063d67ed909536a9809cbe47602e035ea",
   "99-magic-sysrq.conf": "a093a9eeb54c72b32ea4e2d673562c2da94361b68a3873a95e95a6da7f0127dc",
-  "99-yama-ptrace.conf": "5a4876d61267e5748b4765923a8d169136fc5c161d7f363250dc24849c7cfe80",
+  "99-yama-ptrace.conf": "f7881466bff200865ec2c6b5f989ed35855ac45420a55ae5ace805f9e5111828",
   "99-net-core-bpf-jit-harden.conf": "5eb31e2e240cab5f57217be2e9460af2cb989d9e3fc4c7c7b50cbba536d8e7f2",
   "99-kernel.conf": "0ddcedb57a5ec3be92ffd6ea88b2fd4e1ab16e8fee0fda58727757c77ad688cb",
   "99-tcp-timestamps.conf": "24c4dc723691ab259f805828ec9f5f6320ba54ff2be6c5b1d0d9fec972d705b3",

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -1,4 +1,3 @@
-
 # We ship a .pc file but don't want to have a dep on pkg-config. We
 # strip the automatically generated dep here and instead co-own the
 # directory.
@@ -50,7 +49,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        28%{?dist}
+Release:        29%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -1237,6 +1236,10 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Tue May 23 2025 kintali Jayanth <kintalix.jayanth@intel.com> - 255-29
+- Change value of kernel.yama.ptrace_scope to 0 (Normal ptrace
+  security permissions)
+
 * Tue May 20 2025 Basavaraj unniche <basavarajx.unniche@intel.com> - 255-28
 - Add kernel command to disable TCP timestamps.
 


### PR DESCRIPTION
- Updated 99-yama-ptrace.conf to set kernel.yama.ptrace_scope = 0
- Updated systemd.signatures.json with new hash for the .conf file
- Added the changelog entry and bumped release in systemd.spec
- This setting disables ptrace restrictions. Any process can trace any other. Useful for development and debugging. Use 'sysctl kernel.yama.ptrace_scope' to check the current setting.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
updated the value kernel.yama.ptrace_scope to zero to disable to any ptrace restrictions.

<!-- Fixes # (issue) -->


#### Any Newly Introduced Dependencies
No

#### How Has This Been Tested? <!-- REQUIRED -->
First systemd rpm has built with modified systemd spec file.
With above systemd binaries, created iso and installed on system. verified as below.

<img width="442" alt="image" src="https://github.com/user-attachments/assets/b198bf97-d3be-493a-9de7-0a3873bfca1c" />

