### PR TITLE
Fixing references to toolkit docs

### DIFF
--- a/docs/developer-guide/get-started/building-howto.md
+++ b/docs/developer-guide/get-started/building-howto.md
@@ -19,7 +19,7 @@ of the resulting image, such as:
   immutable image, second stage bootloader provider, purge documentation etc.).
 
 Before you can build OS images you need to build the toolchain and make sure to
-[**install pre-requisites (Ubuntu)**](/toolkit/docs/building/prerequisites-ubuntu.md).
+[**install pre-requisites (Ubuntu)**](https://github.com/open-edge-platform/edge-microvisor-toolkit/blob/3.0/toolkit/docs/building/prerequisites-ubuntu.md).
 
 > **Note:**
   Use the *stable* tag instead of *latest* for building the OS images with prebuilt packages.
@@ -359,4 +359,4 @@ Example : `sha256sum ./SPECS/node-agent/env_wrapper.sh`
 ## Next
 
 - Learn how to [Enable Secure Boot for Edge Microvisor Toolkit](sb-howto.md).
-- See the detailed description of how to [create a full build and customize it](/toolkit/docs/building/add-package.md).
+- See the detailed description of how to [create a full build and customize it](https://github.com/open-edge-platform/edge-microvisor-toolkit/blob/3.0/toolkit/docs/building/add-package.md).


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
References to `/toolkit/docs` resources in [Build an Edge Microvisor Toolkit Image](https://docs.openedgeplatform.intel.com/edge-microvisor-toolkit/3.0/developer-guide/get-started/building-howto.html) are broken. I have provided absolute paths to files on GitHub repository to fix this issue. 



