### PR TITLE
Fix GPU detection in HW Discovery Agent when vendor information missing

### DIFF
--- a/SPECS/hardware-discovery-agent/hardware-discovery-agent.signatures.json
+++ b/SPECS/hardware-discovery-agent/hardware-discovery-agent.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "hardware-discovery-agent-1.6.1.tar.gz": "fb1d8d6f0bade2ce4fba3555f19757f7a98b2f5022532eaf09b31cc4db5e2ace",
+    "hardware-discovery-agent-1.7.0.tar.gz": "f30903d85e78293f82f5d56ec0ff0783f3d48338bfe7a18beb4268ab768dd11f",
     "hardware-discovery-agent.service": "2c3151d61ca649ced26764de6008833fbcab45a966b6f18f4113d4cf5a4846b7",
     "env_wrapper.sh": "0fa0e748f2d1c0b81c240fa59fac4647571518c53479000adb4ba467031cccf6",
     "hardware-discovery-agent.conf": "ffb9cbd4bf7b95c5dc39d3bc84ab7279b034203533c63856818638636f41c01a",

--- a/SPECS/hardware-discovery-agent/hardware-discovery-agent.spec
+++ b/SPECS/hardware-discovery-agent/hardware-discovery-agent.spec
@@ -1,6 +1,6 @@
 Summary:        Edge node hardware information reporting
 Name:           hardware-discovery-agent
-Version:        1.6.1
+Version:        1.7.0
 Release:        1%{?dist}
 License:        Apache-2.0
 Vendor:         Intel Corporation
@@ -115,6 +115,10 @@ install -m 644 %{modulename}.pp %{buildroot}%{_datadir}/selinux/packages/%{modul
 %selinux_modules_uninstall -s %{selinuxtype} %{modulename}
 
 %changelog
+* Tue May 27 2025 Christopher Nolan <christopher.nolan@intel.com> - 1.7.0-1
+- Fix GPU detection when vendor information is empty
+- HW Discovery Agent version 1.7.0
+
 * Thu Apr 03 2025 Rajeev Ranjan <rajeev2.ranjan@intel.com> - 1.6.1-1
 - Update common to 1.6.8
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -5230,8 +5230,8 @@
         "type": "other",
         "other": {
           "name": "hardware-discovery-agent",
-          "version": "1.6.1",
-          "downloadUrl": "https://github.com/open-edge-platform/edge-node-agents/archive/refs/tags/hardware-discovery-agent/v1.6.1.tar.gz"
+          "version": "1.7.0",
+          "downloadUrl": "https://github.com/open-edge-platform/edge-node-agents/archive/refs/tags/hardware-discovery-agent/v1.7.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [] Ready to merge

#### Description <!-- REQUIRED -->
- Fixes GPU detection in HW Discovery Agent when some information, such as vendor, is missing from lshw for GPU devices
- Updates HW Discovery Agent to version 1.7.0

<!-- Fixes #68089 -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
