### PR TITLE
[Tink] Add rpc package into tink image

### DIFF
--- a/toolkit/imageconfigs/packagelists/tink-packages.json
+++ b/toolkit/imageconfigs/packagelists/tink-packages.json
@@ -1,5 +1,6 @@
 {
     "packages": [
+        "rpc",
         "dracut-tmpfsroot",
         "tar",
         "fluent-bit",

--- a/toolkit/imageconfigs/scripts/generate-tink-initramfs.sh
+++ b/toolkit/imageconfigs/scripts/generate-tink-initramfs.sh
@@ -31,20 +31,20 @@ function generate_images() {
     #cp "/tmp/$arfname.tar.gz" "$outputdir"
 
     ramfs=$(find $outputdir -type f -name initramfs*img -printf '%f\n')
-    echo "pprefix: Original $ramfs $(sync;du -h $outputdir/$ramfs)"
+    echo "$pprefix: Original $ramfs $(sync;du -h $outputdir/$ramfs)"
     # unzip initramfs
     mkdir -p /tmp/initramfs
     cd /tmp/initramfs
-    echo "pprefix: inside $(pwd)"
-    echo "pprefix: unziping initial initramfs for repack"
+    echo "$pprefix: inside $(pwd)"
+    echo "$pprefix: unziping initial initramfs for repack"
     gunzip -c -k "$outputdir/$ramfs" | cpio -idmv --no-absolute-filenames
-    #echo "pprefix: free space $(df -h)"
+    #echo "$pprefix: free space $(df -h)"
 
     cp "/tmp/$arfname.tar.gz" /tmp/initramfs/
     find . | cpio -o -H newc | gzip > "$outputdir/$ramfs"
     cd -
 
-    echo "pprefix: $(sync;du -h $outputdir/$ramfs)"
+    echo "$pprefix: $(sync;du -h $outputdir/$ramfs)"
     rm -rf /tmp/initramfs
     chmod 0666 $outputdir/vmlinuz-*.emt3 $outputdir/initramfs-*.emt3.img
 }

--- a/toolkit/imageconfigs/scripts/setup-tink-image.sh
+++ b/toolkit/imageconfigs/scripts/setup-tink-image.sh
@@ -18,7 +18,7 @@ if [ ! -f /etc/fluent-bit/fluent-bit.conf ]; then
 fi
 echo "$pprefix: fstab contents $(cat /etc/fstab)"
 echo 'tmpfs   /   tmpfs   defaults,size=1G   0   0' > /etc/fstab
-echo "$pprefix: $(du -h /usr/share)"
+echo "$pprefix: $(du -ah /usr/share)"
 find /usr/share -type f \
   ! -path "/usr/share/terminfo/v/vt100" \
   ! -path "/usr/share/terminfo/v/vt220" \
@@ -31,8 +31,9 @@ find /usr/share -type f \
   ! -path "/usr/share/pki/*" \
   ! -path "/usr/share/p11-kit/*" \
   ! -path "/usr/share/licenses/*" \
+  ! -path "/usr/share/*.cer" \
   -exec rm -f {} +
-echo "$pprefix: reduced $(du -h /usr/share)"
+echo "$pprefix: reduced $(du -ah /usr/share)"
 
 ramfs=$(find /boot -type f -name initramfs*img -printf '%f\n')
 # unzip initramfs


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Add rpc package into tink build as part for vPRO AMT requirement

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
build and generate vmlinuz/initramfs from generate-tink-initramfs.sh, check that rpc package files are present in rootfs after run and rpc binary is executable.
root@localhost [ ~ ]# ls /usr/share/*.cer
/usr/share/OnDie_CA_RootCA_Certificate.cer
root@localhost [ ~ ]# rpc
ERRO[0000] AMT not found: MEI/driver is missing or the call to the HECI driver failed
ERRO[0000] Failed to execute due to access issues. Please ensure that Intel ME is present, the MEI driver is installed, and the runtime has administrator or root privil
ERRO[0000] Error 2: HECIDriverNotDetected
