### PR TITLE
[TINK] Add packages for tink image and retain dbus-1 file in /usr/share

### DIFF
--- a/toolkit/imageconfigs/packagelists/tink-packages.json
+++ b/toolkit/imageconfigs/packagelists/tink-packages.json
@@ -5,6 +5,12 @@
         "fluent-bit",
         "caddy",
         "rng-tools",
-        "containerd"
+        "containerd",
+        "gawk",
+        "efibootmgr",
+        "lvm2",
+        "parted",
+        "net-tools",
+        "cryptsetup"
     ]
 }

--- a/toolkit/imageconfigs/scripts/setup-tink-image.sh
+++ b/toolkit/imageconfigs/scripts/setup-tink-image.sh
@@ -31,6 +31,7 @@ find /usr/share -type f \
   ! -path "/usr/share/pki/*" \
   ! -path "/usr/share/p11-kit/*" \
   ! -path "/usr/share/licenses/*" \
+  ! -path "/usr/share/dbus-1/*" \
   -exec rm -f {} +
 echo "$pprefix: reduced $(du -h /usr/share)"
 


### PR DESCRIPTION
Add additional packages to support SEN
Retain files in /usr/share/dbus-1, which are required by getty service

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Added additional packages in toolkit/imageconfigs/packagelists/tink-packages.json file, they are required by SEN deployment
and it will increase around 3~4MB to the size of generated initramfs-*-emt3.img
/usr/share/dbus-1/*,  are needed by getty service, they can not be removed.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Tested the tink-image in tinker-bell playground
