### PR TITLE
Revert "daily_build: restore override REPO_LIST (#143)"

### DIFF
--- a/toolkit/scripts/daily_build.mk
+++ b/toolkit/scripts/daily_build.mk
@@ -75,7 +75,6 @@ ifneq ($(DAILY_BUILD_REPO),)
                                  $(PACKAGE_ROOT)/RPMS/noarch \
 				 $(PACKAGE_ROOT)/RPMS/debuginfo \
 				 $(PACKAGE_URL_LIST)
-   override REPO_LIST         += $(DAILY_BUILD_REPO)
    override SRPM_URL_LIST     := $(PACKAGE_ROOT)/SRPMS \
 				 $(SRPM_URL_LIST)
 endif


### PR DESCRIPTION
This reverts commit 83e00c4bd7c679610d83f58389fc1b6627c6facf.

REPO_LIST were restore to fix mismatch rpm for some build, but is causing scheduler to break while running delta build. Need further investigation for the issue hence revert this for now.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
