### PR TITLE
[EMT-X11] Docker for desktop virtualization image

### DIFF
--- a/toolkit/imageconfigs/edge-image-desktop-virtualization-dev.json
+++ b/toolkit/imageconfigs/edge-image-desktop-virtualization-dev.json
@@ -5,11 +5,11 @@
             "MaxSize": 4096,
             "Artifacts": [
                 {
-                    "Name": "edge-readonly-mf-dev",
+                    "Name": "edge-readonly-dv-dev",
                     "Type": "raw"
                 },
                 {
-                    "Name": "edge-readonly-mf-dev",
+                    "Name": "edge-readonly-dv-dev",
                     "Type": "vhd"
                 }
             ],
@@ -76,6 +76,7 @@
                 "packagelists/selinux-full.json",
                 "packagelists/intel-gpu-base.json",
                 "packagelists/os-ab-update.json",
+                "packagelists/docker.json",
                 "packagelists/fs-tools.json"
             ],
             "AdditionalFiles": {
@@ -105,7 +106,7 @@
             ],
             "KernelCommandLine": {
                 "ExtraCommandLine": "quiet splash sysctl.vm.overcommit_memory=1 sysctl.kernel.panic=10 sysctl.kernel.panic_on_oops=1 sysctl.fs.inotify.max_user_instances=8192 rd.shell=0 rd.timeout=200 rd.emergency=reboot udmabuf.list_limit=8192 i915.enable_guc=3 i915.max_vfs=7 intel_iommu=on iommu=pt i915.force_probe=*",
-		        "SELinux": "permissive"
+            "SELinux": "permissive"
             },
             "Hostname": "EdgeMicrovisorToolkit",
             "DisableRpmDocs": true,

--- a/toolkit/imageconfigs/edge-image-desktop-virtualization.json
+++ b/toolkit/imageconfigs/edge-image-desktop-virtualization.json
@@ -5,11 +5,11 @@
             "MaxSize": 4096,
             "Artifacts": [
                 {
-                    "Name": "edge-readonly-mf",
+                    "Name": "edge-readonly-dv",
                     "Type": "raw"
                 },
                 {
-                    "Name": "edge-readonly-mf",
+                    "Name": "edge-readonly-dv",
                     "Type": "vhd"
                 }
             ],
@@ -77,6 +77,7 @@
                 "packagelists/selinux-full.json",
                 "packagelists/intel-gpu-base.json",
                 "packagelists/os-ab-update.json",
+                "packagelists/docker.json",
                 "packagelists/fs-tools.json"
             ],
             "AdditionalFiles": {
@@ -106,7 +107,7 @@
             ],
             "KernelCommandLine": {
                 "ExtraCommandLine": "quiet splash sysctl.vm.overcommit_memory=1 sysctl.kernel.panic=10 sysctl.kernel.panic_on_oops=1 sysctl.fs.inotify.max_user_instances=8192 rd.shell=0 rd.timeout=200 rd.emergency=reboot udmabuf.list_limit=8192 i915.enable_guc=3 i915.max_vfs=7 intel_iommu=on iommu=pt i915.force_probe=*",
-		        "SELinux": "permissive"
+            "SELinux": "permissive"
             },
             "Hostname": "EdgeMicrovisorToolkit",
             "DisableRpmDocs": true,


### PR DESCRIPTION
Add docker-compose support for desktop virtualization images Rename built images from mf to dv

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Add docker-compose support into desktop virtualization images config as per requirements.
renamed built images to remove mf as dv (desktop requirements) as per request.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Yes. Both edge-image-desktop-virtualization and edge-image-desktop-virtualization-dev have been built successfully and booted to start docker service successfully.
