### PR TITLE
Update CA/HDA/PTA/PUA versions for grpc retry

### DIFF
--- a/SPECS/cluster-agent/cluster-agent.signatures.json
+++ b/SPECS/cluster-agent/cluster-agent.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "cluster-agent-1.7.2.tar.gz": "96aef8319bb7800b69e42bd4e652e2253e8520bd7118e2088fd940e41e9cb2f4",
+    "cluster-agent-1.7.3.tar.gz": "6e12e15456034ef3be0306cd81005c920cb7e74dc70ccbae4e7965f0eb59ff6c",
     "cluster-agent.service": "e484c560bf881ebd12024404afc68f80493692280f6c5045990fe575ffb746bb",
     "env_wrapper.sh": "9b1dff883e0d38e5968e7e86363919303da0b3d0213888e7b2ed3c7659c8319c",
     "cluster-agent.conf": "4324f15acaa9d78738c231867f504c53d753a184a59538e6ccf679d4b8642f36",

--- a/SPECS/cluster-agent/cluster-agent.spec
+++ b/SPECS/cluster-agent/cluster-agent.spec
@@ -1,6 +1,6 @@
 Summary:        Installs/uninstalls orchestration software on an edge node using command obtained from Cluster Orchestrator.
 Name:           cluster-agent
-Version:        1.7.2
+Version:        1.7.3
 Release:        1%{?dist}
 License:        Apache-2.0
 Vendor:         Intel Corporation
@@ -128,6 +128,9 @@ install -m 644 %{modulename}.pp %{buildroot}%{_datadir}/selinux/packages/%{modul
 %selinux_modules_uninstall -s %{selinuxtype} %{modulename}
 
 %changelog
+* Wed Jun 04 2025 Rajeev Ranjan <rajeev2.ranjan@intel.com> - 1.7.3-1
+- Add backoff/retry on northbound grpc interfaces
+
 * Tue May 27 2025 Andy Bavier <andy.bavier@intel.com> - 1.7.2-1
 - Allow cluster-agent to exec base64 cmd
 

--- a/SPECS/hardware-discovery-agent/hardware-discovery-agent.signatures.json
+++ b/SPECS/hardware-discovery-agent/hardware-discovery-agent.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "hardware-discovery-agent-1.7.0.tar.gz": "f30903d85e78293f82f5d56ec0ff0783f3d48338bfe7a18beb4268ab768dd11f",
+    "hardware-discovery-agent-1.7.1.tar.gz": "fa6031c2fb1c9af081b664bd4709fc088c51cb828c8a10eaa569dd0b9b7cc91e",
     "hardware-discovery-agent.service": "2c3151d61ca649ced26764de6008833fbcab45a966b6f18f4113d4cf5a4846b7",
     "env_wrapper.sh": "0fa0e748f2d1c0b81c240fa59fac4647571518c53479000adb4ba467031cccf6",
     "hardware-discovery-agent.conf": "ffb9cbd4bf7b95c5dc39d3bc84ab7279b034203533c63856818638636f41c01a",

--- a/SPECS/hardware-discovery-agent/hardware-discovery-agent.spec
+++ b/SPECS/hardware-discovery-agent/hardware-discovery-agent.spec
@@ -1,6 +1,6 @@
 Summary:        Edge node hardware information reporting
 Name:           hardware-discovery-agent
-Version:        1.7.0
+Version:        1.7.1
 Release:        1%{?dist}
 License:        Apache-2.0
 Vendor:         Intel Corporation
@@ -115,6 +115,9 @@ install -m 644 %{modulename}.pp %{buildroot}%{_datadir}/selinux/packages/%{modul
 %selinux_modules_uninstall -s %{selinuxtype} %{modulename}
 
 %changelog
+* Wed Jun 04 2025 Rajeev Ranjan <rajeev2.ranjan@intel.com> - 1.7.1-1
+- Add backoff/retry on northbound grpc interfaces
+
 * Tue May 27 2025 Christopher Nolan <christopher.nolan@intel.com> - 1.7.0-1
 - Fix GPU detection when vendor information is empty
 - HW Discovery Agent version 1.7.0

--- a/SPECS/platform-telemetry-agent/platform-telemetry-agent.signatures.json
+++ b/SPECS/platform-telemetry-agent/platform-telemetry-agent.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "platform-telemetry-agent-1.3.1.tar.gz": "d3c85f02b94d05aabbca869a3826824b23732e2605c370dd1c74db66ac862295",
+    "platform-telemetry-agent-1.4.0.tar.gz": "a848536225ab20ad4a99c0ae3c03eb44127954f7593a172368d273d3d9aecaf6",
     "platform-telemetry-agent.service": "441d64259c0cb4ee1c5a1ca4fff06454abdab66ddbc01c496e2efcc0ceb88aee",
     "env_wrapper.sh": "e3d9c27c8e31f6a2a3e530ce31fb6c3078ea3c9cdd4647d5151d9ea7f58296c7",
     "platform-telemetry-agent.conf": "555a6fcec46c3a27139b4946e3eae30df2fc8a61c83efe2fc616492fee11a925",

--- a/SPECS/platform-telemetry-agent/platform-telemetry-agent.spec
+++ b/SPECS/platform-telemetry-agent/platform-telemetry-agent.spec
@@ -4,7 +4,7 @@
 
 Summary:        An agent for managing and updating metric and log configurations
 Name:           platform-telemetry-agent
-Version:        1.3.1
+Version:        1.4.0
 Release:        1%{?dist}
 License:        Apache-2.0
 Vendor:         Intel Corporation
@@ -147,6 +147,9 @@ echo "Assigning KUBECONFIG End"
 %systemd_postun platform-telemetry-agent.service
 
 %changelog
+* Wed Jun 04 2025 Rajeev Ranjan <rajeev2.ranjan@intel.com> - 1.4.0-1
+- Add backoff/retry on northbound grpc interfaces
+
 * Thu Apr 03 2025 Rajeev Ranjan <rajeev2.ranjan@intel.com> - 1.3.1-1
 - Update common to 1.6.8
 

--- a/SPECS/platform-update-agent/platform-update-agent.signatures.json
+++ b/SPECS/platform-update-agent/platform-update-agent.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "platform-update-agent-1.5.1.tar.gz": "9bbbc7ee29694b355e2e60cc174788969049b95283380eb5cbc7996a6614b900",
+    "platform-update-agent-1.5.2.tar.gz": "c0f7d5df0699c09b12c2419ef414737ddf81ea78c5a6311765093a3b7c73b4f6",
     "platform-update-agent.service": "e64c76941527f7a74c8d9c8119adbf202edcf6239fe11f6ef67610b73a152d5e",
     "env_wrapper.sh": "b42ae5895c55e88c34a0bd9c4fac04a26dbf213052aae4dd03d225774188ff1f",
     "platform-update-agent.conf": "5fd67227ac36173bb271d36a48d5c1ac75c6775253c0b3f03f3ccae9981745fa",

--- a/SPECS/platform-update-agent/platform-update-agent.spec
+++ b/SPECS/platform-update-agent/platform-update-agent.spec
@@ -3,7 +3,7 @@
 
 Summary:        An agent for updating the OS and bare metal agents packages
 Name:           platform-update-agent
-Version:        1.5.1
+Version:        1.5.2
 Release:        1%{?dist}
 License:        Apache-2.0
 Vendor:         Intel Corporation
@@ -133,6 +133,9 @@ rm -rf %{_var}/edge-node/pua
 echo "Successfully purged platform-update-agent"
 
 %changelog
+* Wed Jun 04 2025 Rajeev Ranjan <rajeev2.ranjan@intel.com> - 1.5.2-1
+- Add backoff/retry on northbound grpc interfaces
+
 * Wed May 28 2025  Yeng Liong Wong <yeng.liong.wong@intel.com> - 1.5.1-1
 - Upgrade agent version to 1.5.1
 - Improve the PUA startup time

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1847,8 +1847,8 @@
         "type": "other",
         "other": {
           "name": "cluster-agent",
-          "version": "1.7.2",
-          "downloadUrl": "https://github.com/open-edge-platform/edge-node-agents/archive/refs/tags/cluster-agent/v1.7.2.tar.gz"
+          "version": "1.7.3",
+          "downloadUrl": "https://github.com/open-edge-platform/edge-node-agents/archive/refs/tags/cluster-agent/v1.7.3.tar.gz"
         }
       }
     },
@@ -5240,8 +5240,8 @@
         "type": "other",
         "other": {
           "name": "hardware-discovery-agent",
-          "version": "1.7.0",
-          "downloadUrl": "https://github.com/open-edge-platform/edge-node-agents/archive/refs/tags/hardware-discovery-agent/v1.7.0.tar.gz"
+          "version": "1.7.1",
+          "downloadUrl": "https://github.com/open-edge-platform/edge-node-agents/archive/refs/tags/hardware-discovery-agent/v1.7.1.tar.gz"
         }
       }
     },
@@ -21523,8 +21523,8 @@
         "type": "other",
         "other": {
           "name": "platform-telemetry-agent",
-          "version": "1.3.1",
-          "downloadUrl": "https://github.com/open-edge-platform/edge-node-agents/archive/refs/tags/platform-telemetry-agent/v1.3.1.tar.gz"
+          "version": "1.4.0",
+          "downloadUrl": "https://github.com/open-edge-platform/edge-node-agents/archive/refs/tags/platform-telemetry-agent/v1.4.0.tar.gz"
         }
       }
     },
@@ -21533,8 +21533,8 @@
         "type": "other",
         "other": {
           "name": "platform-update-agent",
-          "version": "1.5.1",
-          "downloadUrl": "https://github.com/open-edge-platform/edge-node-agents/archive/refs/tags/platform-update-agent/v1.5.1.tar.gz"
+          "version": "1.5.2",
+          "downloadUrl": "https://github.com/open-edge-platform/edge-node-agents/archive/refs/tags/platform-update-agent/v1.5.2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Following versions of edge node agents adds retries & backoff to corresponding northbound grpc services.
Cluster agent v1.7.3
Hardware discovery agent v1.7.1
Platform telemetry agent v1.4.0
Platform update agent v1.5.2

- https://github.com/open-edge-platform/edge-node-agents/pull/101 

Fixes # 68417

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Sanity to provision EN & setup cluster carried out with changes cherry-picked on 3.0 (3.0-dev not working) in branch [rranjan3-test](https://github.com/open-edge-platform/edge-microvisor-toolkit/tree/rranjan3-test)

![image](https://github.com/user-attachments/assets/6fbe47f2-30bb-448d-993f-ff9d4f1936a9)

