### PR TITLE
Add unmount service and udevd override to prevent unmount failures

### DIFF
--- a/toolkit/imageconfigs/additionalconfigs/enable-unmount.sh
+++ b/toolkit/imageconfigs/additionalconfigs/enable-unmount.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+systemctl enable unmount.service
+

--- a/toolkit/imageconfigs/additionalconfigs/systemd-udevd-override.conf
+++ b/toolkit/imageconfigs/additionalconfigs/systemd-udevd-override.conf
@@ -1,0 +1,7 @@
+[Unit]
+Before=umount.target
+
+[Service]
+KillMode=control-group
+SendSIGKILL=yes
+TimeoutStopSec=5s

--- a/toolkit/imageconfigs/additionalconfigs/unmount.service
+++ b/toolkit/imageconfigs/additionalconfigs/unmount.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Force unmount of /var and /etc/udev
+DefaultDependencies=no
+Before=umount.target
+After=systemd-udevd.service systemd-journald.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/umount -l /var
+ExecStart=/bin/umount -l /etc/udev
+
+[Install]
+WantedBy=umount.target

--- a/toolkit/imageconfigs/edge-image-dev.json
+++ b/toolkit/imageconfigs/edge-image-dev.json
@@ -82,7 +82,9 @@
                 "additionalconfigs/layout.env": "/etc/layout.env",
                 "additionalconfigs/99-dhcp-en.network": "/etc/systemd/network/99-dhcp-en.network",
                 "additionalconfigs/systemd-networkd-wait-online-override.conf": "/etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf",
-                "additionalconfigs/emt-cloud-init.cfg": "/etc/cloud/cloud.cfg"
+                "additionalconfigs/emt-cloud-init.cfg": "/etc/cloud/cloud.cfg",
+                "additionalconfigs/unmount.service": "/etc/systemd/system/unmount.service",
+                "additionalconfigs/systemd-udevd-override.conf": "/etc/systemd/system/systemd-udevd.service.d/override.conf"
             },
             "PostInstallScripts": [
                 {
@@ -90,6 +92,9 @@
                 },
                 {
                         "Path": "additionalconfigs/add-sudoer.sh"
+                },
+                {
+                        "Path": "additionalconfigs/enable-unmount.sh"
                 }
             ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/edge-image-rt-dev.json
+++ b/toolkit/imageconfigs/edge-image-rt-dev.json
@@ -82,7 +82,9 @@
                 "additionalconfigs/layout.env": "/etc/layout.env",
                 "additionalconfigs/99-dhcp-en.network": "/etc/systemd/network/99-dhcp-en.network",
                 "additionalconfigs/systemd-networkd-wait-online-override.conf": "/etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf",
-                "additionalconfigs/emt-cloud-init.cfg": "/etc/cloud/cloud.cfg"
+                "additionalconfigs/emt-cloud-init.cfg": "/etc/cloud/cloud.cfg",
+                "additionalconfigs/unmount.service": "/etc/systemd/system/unmount.service",
+                "additionalconfigs/systemd-udevd-override.conf": "/etc/systemd/system/systemd-udevd.service.d/override.conf"
             },
             "PostInstallScripts": [
                 {
@@ -90,6 +92,9 @@
                 },
                 {
                         "Path": "additionalconfigs/add-sudoer.sh"
+                },
+                {
+                        "Path": "additionalconfigs/enable-unmount.sh"
                 }
             ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/edge-image-rt.json
+++ b/toolkit/imageconfigs/edge-image-rt.json
@@ -1,3 +1,4 @@
+
 {
     "Disks": [
         {
@@ -82,7 +83,9 @@
                 "additionalconfigs/layout.env": "/etc/layout.env",
                 "additionalconfigs/99-dhcp-en.network": "/etc/systemd/network/99-dhcp-en.network",
                 "additionalconfigs/systemd-networkd-wait-online-override.conf": "/etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf",
-                "additionalconfigs/emt-cloud-init.cfg": "/etc/cloud/cloud.cfg"
+                "additionalconfigs/emt-cloud-init.cfg": "/etc/cloud/cloud.cfg",
+                "additionalconfigs/unmount.service": "/etc/systemd/system/unmount.service",
+                "additionalconfigs/systemd-udevd-override.conf": "/etc/systemd/system/systemd-udevd.service.d/override.conf"
             },
             "PostInstallScripts": [
                 {
@@ -90,6 +93,9 @@
                 },
                 {
                     "Path": "additionalconfigs/add-sudoer.sh"
+                },
+                {
+                    "Path": "additionalconfigs/enable-unmount.sh"
                 }
 	    ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/edge-image.json
+++ b/toolkit/imageconfigs/edge-image.json
@@ -82,7 +82,9 @@
                 "additionalconfigs/layout.env": "/etc/layout.env",
                 "additionalconfigs/99-dhcp-en.network": "/etc/systemd/network/99-dhcp-en.network",
                 "additionalconfigs/systemd-networkd-wait-online-override.conf": "/etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf",
-                "additionalconfigs/emt-cloud-init.cfg": "/etc/cloud/cloud.cfg"
+                "additionalconfigs/emt-cloud-init.cfg": "/etc/cloud/cloud.cfg",
+                "additionalconfigs/unmount.service": "/etc/systemd/system/unmount.service",
+                "additionalconfigs/systemd-udevd-override.conf": "/etc/systemd/system/systemd-udevd.service.d/override.conf"
             },
             "PostInstallScripts": [
 		{
@@ -90,6 +92,9 @@
 		},
 		{
 			"Path": "additionalconfigs/add-sudoer.sh"
+		},
+		{
+                        "Path": "additionalconfigs/enable-unmount.sh"
 		}
 	    ],
             "KernelOptions": {


### PR DESCRIPTION
- Added unmount.service to force unmount of /var and /etc/udev
   before shutdown
- Created override.conf for systemd-udevd.service to ensure it stops
   before umount.target
- Ensured all child processes of udevd are killed cleanly with a
  timeout
- Enabled unmount.service via post-install script to integrate with
   build process
- Prevents shutdown errors due to kernel PID holding /var or
  /etc/udev

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Fix to avoid failure log prints during the reboot.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->
No

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Generated raw image and tested, Verified that the error message is not coming during reboot.

![image](https://github.com/user-attachments/assets/1970a311-caf8-4152-9523-54d314fc4224)

