### PR TITLE
Fix Sidebar Update for Calamare's

### DIFF
--- a/SPECS/calamares/c69e229be0be9bd7a033776ebe3bec63206b8151.patch
+++ b/SPECS/calamares/c69e229be0be9bd7a033776ebe3bec63206b8151.patch
@@ -1,0 +1,54 @@
+From c69e229be0be9bd7a033776ebe3bec63206b8151 Mon Sep 17 00:00:00 2001
+From: Adriaan de Groot <groot@kde.org>
+Date: Thu, 22 Feb 2024 20:26:56 +0100
+Subject: [PATCH] [calamares] Use a "real" slot for UniqueConnection
+
+Multiple reports of the following fatal error:
+    WARNING (Qt): QObject::connect(QItemSelectionModel, PartitionPage):
+    unique connections require a pointer to member function of a QObject subclass
+suggest to replace the unique lambda by a "real" slot.
+---
+ src/calamares/progresstree/ProgressTreeView.cpp | 17 +++++++++++------
+ src/calamares/progresstree/ProgressTreeView.h   |  3 +++
+ 2 files changed, 14 insertions(+), 6 deletions(-)
+
+diff --git a/src/calamares/progresstree/ProgressTreeView.cpp b/src/calamares/progresstree/ProgressTreeView.cpp
+index 900dd5028d..9d49ea288e 100644
+--- a/src/calamares/progresstree/ProgressTreeView.cpp
++++ b/src/calamares/progresstree/ProgressTreeView.cpp
+@@ -47,10 +47,15 @@ ProgressTreeView::setModel( QAbstractItemModel* model )
+ 
+     QListView::setModel( model );
+ 
+-    connect(
+-        Calamares::ViewManager::instance(),
+-        &Calamares::ViewManager::currentStepChanged,
+-        this,
+-        [ this ]() { viewport()->update(); },
+-        Qt::UniqueConnection );
++    connect( Calamares::ViewManager::instance(),
++             &Calamares::ViewManager::currentStepChanged,
++             this,
++             &ProgressTreeView::update,
++             Qt::UniqueConnection );
++}
++
++void
++ProgressTreeView::update()
++{
++    viewport()->update();
+ }
+diff --git a/src/calamares/progresstree/ProgressTreeView.h b/src/calamares/progresstree/ProgressTreeView.h
+index 00decb6c3d..d845cc715b 100644
+--- a/src/calamares/progresstree/ProgressTreeView.h
++++ b/src/calamares/progresstree/ProgressTreeView.h
+@@ -31,6 +31,9 @@ class ProgressTreeView : public QListView
+      * @brief setModel assigns a model to this view.
+      */
+     void setModel( QAbstractItemModel* model ) override;
++
++public Q_SLOTS:
++    void update();
+ };
+ 
+ #endif  // PROGRESSTREEVIEW_H

--- a/SPECS/calamares/calamares.spec
+++ b/SPECS/calamares/calamares.spec
@@ -7,7 +7,7 @@ Summary:        Installer from a live CD/DVD/USB to disk
 # https://github.com/calamares/calamares/issues/1051
 Name:           calamares
 Version:        3.3.1
-Release:        11%{?dist}
+Release:        12%{?dist}
 License:        GPLv3+
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -58,6 +58,7 @@ Patch6:          modules-set-OS-to-EdgeMicrovisorToolkit.patch
 Patch7:          reword-welcome-screen.patch
 Patch8:          change-completion-from-second-to-minute.patch
 Patch9:          ui_redesign.patch
+Patch10:         c69e229be0be9bd7a033776ebe3bec63206b8151.patch
 # Compilation tools
 BuildRequires:  cmake
 BuildRequires:  extra-cmake-modules
@@ -156,6 +157,7 @@ mv %{SOURCE56} data/images/wait.png
 %patch -P 7 -p1
 %patch -P 8 -p1
 %patch -P 9 -p1
+%patch -P 10 -p1
 
 %build
 %cmake_kf \
@@ -233,6 +235,9 @@ install -p -m 644 %{SOURCE21} %{buildroot}%{_sysconfdir}/calamares/settings.conf
 %{_libdir}/libcalamaresui.so
 
 %changelog
+* Tue June 10 2025 kintalix jayanth <kintalix.jayanth@intel.com> - 3.3.1-12
+- Fixed sidebar update issue from upstream.
+
 * Wed April 25 2025 Samuel Taripin <samuel.taripin@intel.com> - 3.3.1-11
 - UI redesign.
 


### PR DESCRIPTION
- Replaced lambda with a real slot to satisfy Qt's UniqueConnection requirement. Taken from upstream commit c69e229

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
Make Sidebar Update Properly in Calamares ViewManager

#### Any Newly Introduced Dependencies
No

#### How Has This Been Tested? 
Tested manually.