### PR TITLE
[AMT] Update intel-lms build options

### DIFF
--- a/SPECS/intel-lms/intel-lms.spec
+++ b/SPECS/intel-lms/intel-lms.spec
@@ -3,7 +3,7 @@
 Summary:        Intel Local Manageability Service allows applications to access the Intel Active Management Technology (AMT) firmware via the Intel Management Engine Interface (MEI).
 Name:           intel-lms
 Version:        2506.0.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Distribution:   Edge Microvisor Toolkit
 Vendor:         Intel Corporation
 License:        Apache-2.0
@@ -40,7 +40,7 @@ Intel Local Manageability Service allows applications to access the Intel Active
 export LMS_ROOT=$(pwd)
 mkdir -p build
 pushd build
-%cmake -Wno-dev -DBUILD_SHARED_LIBS=OFF $LMS_ROOT
+%cmake -Wno-dev -DBUILD_SHARED_LIBS=OFF -DNETWORK_NM=OFF -DNETWORK_CN=OFF -DCMAKE_INSTALL_PREFIX=%{_prefix} $LMS_ROOT
 %cmake_build
 popd
 
@@ -75,5 +75,8 @@ rm -rf %{buildroot}%{_docdir}/lms
 
 
 %changelog
+* Wed Jun 11 2025 Swee Yee Fonn <swee.yee.fonn@intel.com> - 2506.0.0.0-2
+- Modified build flags.
+
 * Fri May 30 2025 Swee Yee Fonn <swee.yee.fonn@intel.com> - 2506.0.0.0-1
 - Original version for Edge Microvisor Toolkit. (license: MIT). License verified.


### PR DESCRIPTION
Update intel-lms build options to remove usage of
Network Manager/Connection Manager frameworks.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Updated intel-lms build flags as requested.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Built edge-image-dev image and tested on vPRO AMT machine that lms service is running after boot and "rpc amtinfo" working.

guest@EdgeMicrovisorToolkit [ ~ ]$ cat /etc/os-release
NAME="Edge Microvisor Toolkit"
VERSION="3.0.20250411"
ID="Edge Microvisor Toolkit"
VERSION_ID="3.0"
PRETTY_NAME="Edge Microvisor Toolkit 3.0"
ANSI_COLOR="1;34"
HOME_URL="https://github.com/open-edge-platform/edge-microvisor-toolkit"
BUG_REPORT_URL="https://github.com/open-edge-platform/edge-microvisor-toolkit"
SUPPORT_URL="https://github.com/open-edge-platform/edge-microvisor-toolkit"
guest@EdgeMicrovisorToolkit [ ~ ]$ sudo systemctl status lms.service
● lms.service - Local Manageability Service
     Loaded: loaded (/usr/lib/systemd/system/lms.service; enabled; preset: disabled)
    Drop-In: /usr/lib/systemd/system/service.d
             └─10-timeout-abort.conf
     Active: active (running) since Wed 2025-06-11 03:41:36 UTC; 4min 53s ago
   Main PID: 1146 (lms)
      Tasks: 9 (limit: 18485)
     Memory: 17.5M (peak: 18.9M)
        CPU: 106ms
     CGroup: /system.slice/lms.service
             └─1146 /usr/bin/lms

Jun 11 03:41:36 EdgeMicrovisorToolkit systemd[1]: Starting lms.service - Local Manageability Service...
Jun 11 03:41:36 EdgeMicrovisorToolkit lms[1146]: (1146)[2025-06-11 03:41:36.599459][LM_DEBUG   ]  BaseWSManClient::WsmanInitializer::WsmanInitializer()
Jun 11 03:41:36 EdgeMicrovisorToolkit lms[1146]: (1146)[2025-06-11 03:41:36.715080][LM_DEBUG   ]  Starting LMS Service
Jun 11 03:41:36 EdgeMicrovisorToolkit LMS[1146]: Local Management Service started.
Jun 11 03:41:36 EdgeMicrovisorToolkit LMS[1146]: Intel(R) Management Engine (Intel(R) ME) error(s) occurred. Please review Intel(R) ME logs.
Jun 11 03:41:36 EdgeMicrovisorToolkit systemd[1]: Started lms.service - Local Manageability Service.
guest@EdgeMicrovisorToolkit [ ~ ]$ sudo rpc amtinfo
Version                 : 16.1.27
Build Number            : 2176
SKU                     : 16392
Features                : AMT Pro Corporate
UUID                    : 89174ecf-31c3-22e3-5f8d-48210b509c73
Control Mode            : pre-provisioning state
DNS Suffix              : kind.internal
DNS Suffix (OS)         : iind.intel.com
Hostname (OS)           : EdgeMicrovisorToolkit
RAS Network             : outside enterprise
RAS Remote Status       : not connected
RAS Trigger             : user initiated
RAS MPS Hostname        :
---Wired Adapter---
DHCP Enabled            : true
DHCP Mode               : passive
Link Status             : up
AMT IP Address          : 0.0.0.0
OS  IP Address          : 10.49.76.164
MAC Address             : 48:21:0b:50:9c:73
---Wireless Adapter---
DHCP Enabled            : true
DHCP Mode               : passive
Link Status             : down
AMT IP Address          : 0.0.0.0
OS  IP Address          : 0.0.0.0
MAC Address             : 00:00:00:00:00:00

