### PR TITLE
otelcol-contrib: fix CVE-2025-22872

### DIFF
--- a/SPECS/otelcol-contrib/CVE-2025-22872.patch
+++ b/SPECS/otelcol-contrib/CVE-2025-22872.patch
@@ -1,0 +1,58 @@
+From 63b0d2e320023dd3e0425bce79cc6d718b533213 Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Mon, 24 Feb 2025 11:18:31 -0800
+Subject: [PATCH] html: properly handle trailing solidus in unquoted attribute
+ value in foreign content
+
+The parser properly treats tags like <p a=/> as <p a="/">, but the
+tokenizer emits the SelfClosingTagToken token incorrectly. When the
+parser is used to parse foreign content, this results in an incorrect
+DOM.
+
+Thanks to Sean Ng (https://ensy.zip) for reporting this issue.
+
+Fixes golang/go#73070
+Fixes CVE-2025-22872
+
+Change-Id: I65c18df6d6244bf943b61e6c7a87895929e78f4f
+Reviewed-on: https://go-review.googlesource.com/c/net/+/661256
+Reviewed-by: Neal Patel <nealpatel@google.com>
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+---
+ _build/vendor/golang.org/x/net/html/token.go | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/_build/vendor/golang.org/x/net/html/token.go b/_build/vendor/golang.org/x/net/html/token.go
+index 3c57880..6598c1f 100644
+--- a/_build/vendor/golang.org/x/net/html/token.go
++++ b/_build/vendor/golang.org/x/net/html/token.go
+@@ -839,8 +839,22 @@ func (z *Tokenizer) readStartTag() TokenType {
+ 	if raw {
+ 		z.rawTag = strings.ToLower(string(z.buf[z.data.start:z.data.end]))
+ 	}
+-	// Look for a self-closing token like "<br/>".
+-	if z.err == nil && z.buf[z.raw.end-2] == '/' {
++	// Look for a self-closing token (e.g. <br/>).
++	//
++	// Originally, we did this by just checking that the last character of the
++	// tag (ignoring the closing bracket) was a solidus (/) character, but this
++	// is not always accurate.
++	//
++	// We need to be careful that we don't misinterpret a non-self-closing tag
++	// as self-closing, as can happen if the tag contains unquoted attribute
++	// values (i.e. <p a=/>).
++	//
++	// To avoid this, we check that the last non-bracket character of the tag
++	// (z.raw.end-2) isn't the same character as the last non-quote character of
++	// the last attribute of the tag (z.pendingAttr[1].end-1), if the tag has
++	// attributes.
++	nAttrs := len(z.attr)
++	if z.err == nil && z.buf[z.raw.end-2] == '/' && (nAttrs == 0 || z.raw.end-2 != z.attr[nAttrs-1][1].end-1) {
+ 		return SelfClosingTagToken
+ 	}
+ 	return StartTagToken
+-- 
+2.34.1
+

--- a/SPECS/otelcol-contrib/otelcol-contrib.spec
+++ b/SPECS/otelcol-contrib/otelcol-contrib.spec
@@ -1,7 +1,7 @@
 Summary:        OpenTelemetry Collector Contrib
 Name:           otelcol-contrib
 Version:        0.117.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Apache-2.0
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -11,6 +11,7 @@ URL:            https://github.com/open-telemetry/opentelemetry-collector-releas
 Source0:        %{url}/releases/download/v%{version}/%{name}_%{version}_linux_amd64.tar.gz#/%{name}-%{version}-vendored.tar.gz
 Source1:        otelcol_contrib.te
 Source2:        otelcol_contrib.fc
+Patch0:         CVE-2025-22872.patch
 BuildRequires:  golang
 BuildRequires:  make
 BuildRequires:  systemd-rpm-macros
@@ -67,6 +68,9 @@ install -m 644 %{modulename}.pp %{buildroot}%{_datadir}/selinux/packages/%{modul
 %selinux_modules_uninstall -s %{selinuxtype} %{modulename}
 
 %changelog
+* Fri Jun 13 2025 Tham Jing Hui <jing.hui.tham@intel.com> - 0.117.0-4
+- Include patch for CVE-2025-22872
+
 * Fri Mar 21 2025 Anuj Mittal <anuj.mittal@intel.com> - 0.117.0-3
 - Bump Release to rebuild
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
Go is vulnerable to unexpected DOM behavior due to improper processing of certain formatted tags within the HTML tokenizer of the `x/net/html` module. This can lead to tags being placed in the wrong scope during DOM construction, which could be misinterpreted by applications processing the DOM, and be leveraged by an attacker to perform attacks such as malicious HTML injection.

<!-- Fixes # (issue) -->
CVE2025-22872

#### Any Newly Introduced Dependencies
No

#### How Has This Been Tested? <!-- REQUIRED -->
The package is built with the patch applied.
