### PR TITLE
caddy:fix CVE-2025-22872

### DIFF
--- a/SPECS/caddy/CVE-2025-22872.patch
+++ b/SPECS/caddy/CVE-2025-22872.patch
@@ -1,0 +1,58 @@
+From 9ba151b580e96d9fe4f9a400f91e726119546fff Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Mon, 24 Feb 2025 11:18:31 -0800
+Subject: [PATCH] html: properly handle trailing solidus in unquoted attribute
+ value in foreign content
+
+The parser properly treats tags like <p a=/> as <p a="/">, but the
+tokenizer emits the SelfClosingTagToken token incorrectly. When the
+parser is used to parse foreign content, this results in an incorrect
+DOM.
+
+Thanks to Sean Ng (https://ensy.zip) for reporting this issue.
+
+Fixes golang/go#73070
+Fixes CVE-2025-22872
+
+Change-Id: I65c18df6d6244bf943b61e6c7a87895929e78f4f
+Reviewed-on: https://go-review.googlesource.com/c/net/+/661256
+Reviewed-by: Neal Patel <nealpatel@google.com>
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Auto-Submit: Gopher Robot <gobot@golang.org>
+---
+ vendor/golang.org/x/net/html/token.go | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/vendor/golang.org/x/net/html/token.go b/vendor/golang.org/x/net/html/token.go
+index 3c57880..6598c1f 100644
+--- a/vendor/golang.org/x/net/html/token.go
++++ b/vendor/golang.org/x/net/html/token.go
+@@ -839,8 +839,22 @@ func (z *Tokenizer) readStartTag() TokenType {
+ 	if raw {
+ 		z.rawTag = strings.ToLower(string(z.buf[z.data.start:z.data.end]))
+ 	}
+-	// Look for a self-closing token like "<br/>".
+-	if z.err == nil && z.buf[z.raw.end-2] == '/' {
++	// Look for a self-closing token (e.g. <br/>).
++	//
++	// Originally, we did this by just checking that the last character of the
++	// tag (ignoring the closing bracket) was a solidus (/) character, but this
++	// is not always accurate.
++	//
++	// We need to be careful that we don't misinterpret a non-self-closing tag
++	// as self-closing, as can happen if the tag contains unquoted attribute
++	// values (i.e. <p a=/>).
++	//
++	// To avoid this, we check that the last non-bracket character of the tag
++	// (z.raw.end-2) isn't the same character as the last non-quote character of
++	// the last attribute of the tag (z.pendingAttr[1].end-1), if the tag has
++	// attributes.
++	nAttrs := len(z.attr)
++	if z.err == nil && z.buf[z.raw.end-2] == '/' && (nAttrs == 0 || z.raw.end-2 != z.attr[nAttrs-1][1].end-1) {
+ 		return SelfClosingTagToken
+ 	}
+ 	return StartTagToken
+-- 
+2.34.1
+

--- a/SPECS/caddy/caddy.spec
+++ b/SPECS/caddy/caddy.spec
@@ -3,7 +3,7 @@
 Summary:        Web server with automatic HTTPS
 Name:           caddy
 Version:        2.9.1
-Release:        11%{?dist}
+Release:        12%{?dist}
 Distribution:   Edge Microvisor Toolkit
 Vendor:         Intel Corporation
 # main source code is Apache-2.0
@@ -29,6 +29,7 @@ Source31:       poweredby-black.png
 Patch1:         0001-Disable-commands-that-can-alter-the-binary.patch
 Patch2:         CVE-2025-22869.patch
 Patch3:         CVE-2024-45339.patch
+Patch4:         CVE-2025-22872.patch
 BuildRequires:  go-rpm-macros
 # https://github.com/caddyserver/caddy/commit/2028da4e74cd41f0f7f94222c6599da1a371d4b8
 BuildRequires:  golang >= 1.22.3
@@ -451,6 +452,9 @@ fi
 %{_datadir}/fish/vendor_completions.d/caddy.fish
 
 %changelog
+* Fri Jun 13 2025 Tham Jing Hui <jing.hui.tham@intel.com> - 2.9.1-12
+- Include patch for CVE-2025-22872
+
 * Mon May 19 2025 Rajeev Ranjan <rajeev2.ranjan@intel.com> - 2.9.1-11
 - Drop post-caddy.sh for service
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
Go is vulnerable to unexpected DOM behavior due to improper processing of certain formatted tags within the HTML tokenizer of the `x/net/html` module. This can lead to tags being placed in the wrong scope during DOM construction, which could be misinterpreted by applications processing the DOM, and be leveraged by an attacker to perform attacks such as malicious HTML injection.

<!-- Fixes # (issue) -->
CVE2025-22872

#### Any Newly Introduced Dependencies
No

#### How Has This Been Tested? <!-- REQUIRED -->
The package is built with the patch applied.