### PR TITLE
Fixing references to the documentation website

### DIFF
--- a/design-proposals/README.md
+++ b/design-proposals/README.md
@@ -7,7 +7,7 @@ design-driven. Before implementation, all significant changes must be first
 discussed, formally documented, and agreed upon.
 This document describes the whole process.
 
-To learn more about Edge Microvisor Toolkit, check the [Edge Microvisor Toolkit documentation](https://docs.openedgeplatform.intel.com/edge-microvisor-toolkit/3.0/docs/index.html)
+To learn more about Edge Microvisor Toolkit, check the [Edge Microvisor Toolkit documentation](https://docs.openedgeplatform.intel.com/edge-microvisor-toolkit/3.0/developer-guide/index.html)
 
 ## The Proposal Process
 
@@ -141,8 +141,8 @@ request or the Feature Request is closed.
 
 ## Help
 
-If you need help with this process, please contact the Project's mantainers
+If you need help with this process, please contact the Project's maintainers and
 contributors by posting to the [Discussions](https://github.com/open-edge-platform/edge-manageability-framework/discussions).
 
 To learn about contributing to Edge Microvisor Toolkit in general, see the
-[contribution guidelines](https://docs.openedgeplatform.intel.com/edge-microvisor-toolkit/3.0/docs/developer-guide/contribution/index.html).
+[contribution guidelines](https://docs.openedgeplatform.intel.com/edge-microvisor-toolkit/3.0/developer-guide/emt-contribution.html).


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
Addressing the issue of broken links in design proposals.
Porting: https://github.com/open-edge-platform/edge-microvisor-toolkit/pull/218
