### PR TITLE
SPEC: upgrading linux firmware version to 20250509

### DIFF
--- a/SPECS/linux-firmware/linux-firmware.signatures.json
+++ b/SPECS/linux-firmware/linux-firmware.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "linux-firmware-20250311.tar.xz": "b1083a36f19aea46f661dcfd4cd462d13933dcb4e7f0dc809525552dd5c3541d"
+    "linux-firmware-20250509.tar.xz": "f2c60d66f226a28130cb5643e6e544d3229673460e127c91ba03f1080cbd703e"
   }
 }

--- a/SPECS/linux-firmware/linux-firmware.spec
+++ b/SPECS/linux-firmware/linux-firmware.spec
@@ -1,7 +1,7 @@
 Summary:        Linux Firmware
 Name:           linux-firmware
-Version:        20250311
-Release:        4%{?dist}
+Version:        20250509
+Release:        1%{?dist}
 License:        GPL+ AND GPLv2+ AND MIT AND Redistributable, no modification permitted
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -157,6 +157,9 @@ cp iwlwifi-ma-b0-gf-a0.pnvm %{buildroot}%{_firmwarepath}
 %{_firmwarepath}/intel/ice
 
 %changelog
+* Wed Jun 18 2025 Junxiao Chang <junxiao.chang@intel.com> - 20250509-1
+- Upgrade i915 GuC firmware version to 70.44.1.
+
 +* Tue June 10 2025 shalinix singhal <shalinix.singhal@intel.com> - 20250311-4
 +- Added iwlwifi ucode file in firmware
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -12421,8 +12421,8 @@
         "type": "other",
         "other": {
           "name": "linux-firmware",
-          "version": "20250311",
-          "downloadUrl": "https://www.kernel.org/pub/linux/kernel/firmware/linux-firmware-20250311.tar.xz"
+          "version": "20250509",
+          "downloadUrl": "https://www.kernel.org/pub/linux/kernel/firmware/linux-firmware-20250509.tar.xz"
         }
       }
     },


### PR DESCRIPTION
i915 GuC needs 70.44.1 firmware, which is in 20250509, it is due to kernel upgrading.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Due to kernel upgrade, i915 driver needs 70.44.1 Guc firmware. Upgrading package from 20250311 to 20250509 which has 70.44.1 GuC firmware.
<!-- Fixes # (issue) -->
i915 GuC version doesn't match with kernel requirement.

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Built it to EMT image, no i915 GuC version warning anymore. HW is ADLp.