### PR TITLE
Disable LMS service by default

### DIFF
--- a/SPECS/intel-lms/intel-lms.spec
+++ b/SPECS/intel-lms/intel-lms.spec
@@ -3,7 +3,7 @@
 Summary:        Intel Local Manageability Service allows applications to access the Intel Active Management Technology (AMT) firmware via the Intel Management Engine Interface (MEI).
 Name:           intel-lms
 Version:        2506.0.0.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Distribution:   Edge Microvisor Toolkit
 Vendor:         Intel Corporation
 License:        Apache-2.0
@@ -53,16 +53,26 @@ mkdir -p %{buildroot}%{_datadir}/licenses/%{name}
 cp COPYING %{buildroot}%{_datadir}/licenses/%{name}
 cp -r Docs/Licenses/* %{buildroot}%{_datadir}/licenses/%{name}
 
+mkdir -p %{buildroot}%{_sysconfdir}/lms
+
 # remove unpackaged files
 rm -rf %{buildroot}%{_docdir}/lms
 
-%post -f UNS/linux_scripts/post.rpm
+%systemd_post lms.service
+
+# from UNS/linux_scripts/post.rpm
+# only do following if running in actual system
+if [ -d /run/systemd/system ]; then
+    udevadm control -R && udevadm trigger -c add
+    systemctl restart rsyslog
+fi
 
 %preun -f UNS/linux_scripts/preun.rpm
 
 %files
 %defattr(-,root,root,-)
 %license COPYING
+%dir %{_sysconfdir}/lms
 %{_bindir}/lms
 %{_datadir}/dbus-1/system-services/com.intel.amt.lms.service
 %config %{_sysconfdir}/dbus-1/system.d/com.intel.amt.lms.conf
@@ -75,6 +85,9 @@ rm -rf %{buildroot}%{_docdir}/lms
 
 
 %changelog
+* Mon Jun 23 2025 Swee Yee Fonn <swee.yee.fonn@intel.com> - 2506.0.0.0-3
+- Switch to perform post rpm install actions in spec file instead of calling post.rpm
+
 * Wed Jun 11 2025 Swee Yee Fonn <swee.yee.fonn@intel.com> - 2506.0.0.0-2
 - Modified build flags.
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Disable and mask LMS service by default so that it does not cause systemd to wait for /dev/mei device to appear after boot by default which causes delay in boot time on platforms which do not have mei.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Build edge-image-dev.json and verified boot in Xeon platform (which does not have mei). Before change, boot is 40+ sec. After change:
1.715s (loader) + 2.877s (kernel) + 5.878s (initrd) + 2.773s (userspace)
tested on dut with amt vpro that after enable lms.service manually, "sudo rpc amtinfo" returns expected info and lms service started successfully.

