### PR TITLE
chore: fix multus cni bin path to align with k3s

### DIFF
--- a/SPECS/k3s-multus-cni/k3s-multus-cni.signatures.json
+++ b/SPECS/k3s-multus-cni/k3s-multus-cni.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "k3s-multus-cni-image-v4.2.1.tar": "5b09bb7d675b9f460f9198c253dc761744a15f9fb0d2afd569641fba0e4b6543",
+  "k3s-multus-cni-image-v4.2.1.tar.gz": "c83bf4e47cde7326694e0e941bc1f49625bd912c2d23c38c304b7656af19b08c",
   "k3s-multus-cni-v4.2.1.tar.gz": "7c940f03099b9c9741bea641028859fe4e3e8f657ef922a9cb1c87ebd5e1fe28"
  }
 }

--- a/SPECS/k3s-multus-cni/k3s-multus-cni.spec
+++ b/SPECS/k3s-multus-cni/k3s-multus-cni.spec
@@ -1,6 +1,6 @@
 Name:           k3s-multus-cni
 Version:        4.2.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Multus manifests and container images for k3s kubernetes cluster.
 
 License:        Apache-2.0
@@ -45,6 +45,9 @@ install -m 644 %{SOURCE1} %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/image
 %{_sharedstatedir}/rancher/k3s/agent/images/00-multus/multus-cni.tar
 
 %changelog
+* Mon Jun 23 2025 Hyunsun Moon <hyunsun.moon@intel.com> - 4.2.1-2
+- Update patch to configure additional cni bin path for k3s
+
 * Wed Jun 19 2025 Hyunsun Moon <hyunsun.moon@intel.com> - 4.2.1-1
 - Initial Edge Microvisor Toolkit import from the source project (license: same as "License" tag).
 - License verified.

--- a/SPECS/k3s-multus-cni/k3s-multus-cni.spec
+++ b/SPECS/k3s-multus-cni/k3s-multus-cni.spec
@@ -9,8 +9,8 @@ Distribution:   Edge Microvisor Toolkit
 
 URL:            https://github.com/k8snetworkplumbingwg/multus-cni
 Source0:        https://github.com/k8snetworkplumbingwg/multus-cni/archive/refs/tags/v%{version}.tar.gz#/%{name}-v%{version}.tar.gz
-# Generate image tar by running `docker save ghcr.io/k8snetworkplumbingwg/multus-cni:version -o multus-cni.tar`
-Source1:        %{name}-image-v%{version}.tar
+# Generate image tar by running `docker save ghcr.io/k8snetworkplumbingwg/multus-cni:<version> | gzip > k3s-multus-cni-<version>.tar.gz`
+Source1:        %{name}-image-v%{version}.tar.gz
 Patch0:         multus-daemonset.patch
 Requires:       k3s
 
@@ -27,26 +27,28 @@ This package provides Multus manifests and container image for k3s kubernetes cl
 # No build steps required
 
 %install
-mkdir -p %{buildroot}%{_sharedstatedir}/rancher/k3s/server/manifests/00-multus
-mkdir -p %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/00-multus
+mkdir -p %{buildroot}%{_sharedstatedir}/rancher/k3s/server/manifests/10-multus
+mkdir -p %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/10-multus
 
 # Copy multus manifest
-install -m 644 ./deployments/multus-daemonset.yml %{buildroot}%{_sharedstatedir}/rancher/k3s/server/manifests/00-multus/
+install -m 644 ./deployments/multus-daemonset.yml %{buildroot}%{_sharedstatedir}/rancher/k3s/server/manifests/10-multus/
 
 # Multus manifest uses 1 image
 # 
 # ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1
-install -m 644 %{SOURCE1} %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/00-multus/multus-cni.tar
+install -m 644 %{SOURCE1} %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/10-multus/multus-cni.tar.gz
 
 %files
-%dir %{_sharedstatedir}/rancher/k3s/server/manifests/00-multus
-%dir %{_sharedstatedir}/rancher/k3s/agent/images/00-multus
-%{_sharedstatedir}/rancher/k3s/server/manifests/00-multus/multus-daemonset.yml
-%{_sharedstatedir}/rancher/k3s/agent/images/00-multus/multus-cni.tar
+%dir %{_sharedstatedir}/rancher/k3s/server/manifests/10-multus
+%dir %{_sharedstatedir}/rancher/k3s/agent/images/10-multus
+%{_sharedstatedir}/rancher/k3s/server/manifests/10-multus/multus-daemonset.yml
+%{_sharedstatedir}/rancher/k3s/agent/images/10-multus/multus-cni.tar.gz
 
 %changelog
 * Mon Jun 23 2025 Hyunsun Moon <hyunsun.moon@intel.com> - 4.2.1-2
 - Update patch to configure additional cni bin path for k3s
+- Compress multus cni image in the package
+- Update multus manifest and image directory name
 
 * Wed Jun 19 2025 Hyunsun Moon <hyunsun.moon@intel.com> - 4.2.1-1
 - Initial Edge Microvisor Toolkit import from the source project (license: same as "License" tag).

--- a/SPECS/k3s-multus-cni/multus-daemonset.patch
+++ b/SPECS/k3s-multus-cni/multus-daemonset.patch
@@ -1,6 +1,6 @@
---- multus-cni-4.2.1/deployments/multus-daemonset.yml	2025-05-13 05:32:26.000000000 -0700
-+++ multus-cni-4.2.1/deployments/multus-daemonset.yml	2025-06-20 00:18:09.162689132 -0700
-@@ -179,7 +179,7 @@
+--- multus-cni-4.2.1/deployments/multus-daemonset.yml	2025-06-23 12:01:23
++++ multus-cni-4.2.1/deployments/multus-daemonset.yml	2025-06-23 13:23:59
+@@ -179,12 +179,13 @@
        serviceAccountName: multus
        containers:
        - name: kube-multus
@@ -9,7 +9,13 @@
          command: ["/thin_entrypoint"]
          args:
          - "--multus-conf-file=auto"
-@@ -204,7 +204,7 @@
+         - "--multus-autoconfig-dir=/host/etc/cni/net.d"
+         - "--cni-conf-dir=/host/etc/cni/net.d"
++        - "--additional-bin-dir=/var/lib/rancher/k3s/data/cni"
+         resources:
+           requests:
+             cpu: "100m"
+@@ -204,7 +205,7 @@
            mountPath: /tmp/multus-conf
        initContainers:
          - name: install-multus-binary


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->

Update patch for Multus SPRM to configure k3s specific CNI bin path. This allows Multus to use k3s built-in CNIs, such as bridge, deployed under non-standard CNI bin path.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

First, tested RPM build and install using `containerized-rpmbuild`.

```
sudo make containerized-rpmbuild MODE=test SRPM_PACK_LIST='k3s k3s-calico k8s-multus' DAILY_BUILD_REPO=./resources/manifests/package/development.repo REBUILD_TOOLS=y SOURCE_URL=https://af01p-png.devtools.intel.com/artifactory/tiberos-packages-png-local/CM2/SOURCES EXTRA_ARGS="-e HTTPS_PROXY=http://proxy-dmz.intel.com:912 -e HTTP_PROXY=http://proxy-dmz.intel.com:912 -e NO_PROXY=intel.com,10.*,192.168.*,127.0.0.1,169.254.169.254,::1,localhost"

root [ /mnt ]# tdnf install /repo/noarch/k3s-multus-cni-4.2.1-2.emt3.noarch.rpm 
Loaded plugin: tdnfrepogpgcheck

Installing:
libseccomp                                                     x86_64                                         2.5.5-1.azl3                                                   azurelinux-official-base                       160.13k                                                  74.79k
k3s                                                            x86_64                                         1.30.6-1.azl3                                                  azurelinux-official-cloud-native                75.50M                                                  68.28M
k3s-multus-cni                                                 noarch                                         4.2.1-2.emt3                                                   @cmdline                                       177.83M                                                 177.67M

Total installed size: 253.49M
Total download size: 246.02M
Is this ok [y/N]: y
libseccomp                               76582 100%
warning: /var/cache/tdnf/azurelinux-official-base/rpms/Packages/l/libseccomp-2.5.5-1.azl3.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 3135ce90: NOKEY
importing key from file:///etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
Is this ok [y/N]: y
k3s                                   71600878 100%
Testing transaction
Running transaction
Installing/Updating: libseccomp-2.5.5-1.azl3.x86_64
Installing/Updating: k3s-1.30.6-1.azl3.x86_64
Installing/Updating: k3s-multus-cni-4.2.1-2.emt3.noarch
```

Now, copy generated `multus-daemonset.yml` from containerized-rpmbuild to another machine under `/var/lib/rancher/k3s/server/manifests/10-multus` and install K3s. This test confirms the updated configuration works as expected.

```
kubectl describe po -n kube-system kube-multus-ds-zsckz
Containers:
  kube-multus:
    Container ID:  containerd://ee928b2dc47605761c9a5c25360b5e73d1f5cb5696a77326c033426833d1fda8
    Image:         ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1
    Image ID:      ghcr.io/k8snetworkplumbingwg/multus-cni@sha256:6bebbda31416810875367484b8125026b2816885b79c89c2df863a6ed77dd4a6
    Port:          <none>
    Host Port:     <none>
    Command:
      /thin_entrypoint
    Args:
      --multus-conf-file=auto
      --multus-autoconfig-dir=/host/etc/cni/net.d
      --cni-conf-dir=/host/etc/cni/net.d
      --additional-bin-dir=/var/lib/rancher/k3s/data/cni
```

Try to create `NetworkAttachDefinition` and a test pod with bridge CNI.
```yaml
---
apiVersion: "k8s.cni.cncf.io/v1"
kind: NetworkAttachmentDefinition
metadata:
  name: bridge-network
spec:
  config: |
    {
      "cniVersion": "0.3.1",
      "name": "mynet",
      "type": "bridge",
      "bridge": "mynet0",
      "ipam": {}
    }
---
apiVersion: v1
kind: Pod
metadata:
  name: my-pod
  annotations:
    k8s.v1.cni.cncf.io/networks: '[{"name": "bridge-network", "namespace": "default"}]'
spec:
  containers:
  - name: my-container
    image: busybox
    command: ["sleep", "infinity"]
```

```
seu@hyunsun-k3s:~$ kubectl get po
NAME     READY   STATUS    RESTARTS   AGE
my-pod   1/1     Running   0          5m13s

seu@hyunsun-k3s:~$ kubectl describe po my-pod
Name:             my-pod
Namespace:        default
Priority:         0
Service Account:  default
Node:             hyunsun-k3s/10.114.181.167
Start Time:       Mon, 23 Jun 2025 15:16:24 -0700
Labels:           <none>
Annotations:      cni.projectcalico.org/containerID: 0ad82d4be0d319a4aca247316569d50960724d3e00e571a1642278f49d80c4e8
                  cni.projectcalico.org/podIP: 172.16.252.133/32
                  cni.projectcalico.org/podIPs: 172.16.252.133/32
                  k8s.v1.cni.cncf.io/network-status:
                    [{
                        "name": "k8s-pod-network",
                        "ips": [
                            "172.16.252.133"
                        ],
                        "default": true,
                        "dns": {}
                    },{
                        "name": "default/bridge-network",
                        "interface": "net1",
                        "mac": "d2:7c:f8:4b:9d:5a",
                        "dns": {}
                    }]
                  k8s.v1.cni.cncf.io/networks: [{"name": "bridge-network", "namespace": "default"}]
Status:           Running
IP:               172.16.252.133
```