### PR TITLE
chore: use zstd to compress k3s addon images

### DIFF
--- a/SPECS/intel-gpu-device-plugin/intel-gpu-device-plugin.signatures.json
+++ b/SPECS/intel-gpu-device-plugin/intel-gpu-device-plugin.signatures.json
@@ -1,6 +1,6 @@
 {
     "Signatures": {
         "intel-gpu-device-plugin-v0.32.1.tar.gz": "f098a0d5631027fd9efca5800c246a70817f6918c93e337ed5047c5533cea8a0",
-        "intel-gpu-device-plugin-image-v0.32.1.tar": "82055215bf82ef83e43398bc2275bbee39d745788ae0e35ace708df94d3f3c89"
+        "intel-gpu-device-plugin-image-v0.32.1.tar.zst": "ad9e107953f027331d7123235e36d49e4e810bc962e676d2682daff8cb721b48"
     }
 }

--- a/SPECS/intel-gpu-device-plugin/intel-gpu-device-plugin.spec
+++ b/SPECS/intel-gpu-device-plugin/intel-gpu-device-plugin.spec
@@ -30,5 +30,8 @@ install -m 0644 ./deployments/gpu_plugin/base/intel-gpu-plugin.yaml %{buildroot}
 %{_sharedstatedir}/rancher/k3s/agent/images/00-intel-gpu/intel-gpu-plugin.tar.zst
 
 %changelog
+* Mon Jun 24 2025 Eoghan Lawless <eoghan.lawless@intel.com> - 0.32.1-2
+- Update Source1 to use a zstd-compressed image
+
 * Tue Jun 17 2025 Krishnamurthy Jambur <krishna.j.murthy@intel.com> - 0.32.1-1
 - Original version for Edge Microvisor Toolkit. License verified.

--- a/SPECS/intel-gpu-device-plugin/intel-gpu-device-plugin.spec
+++ b/SPECS/intel-gpu-device-plugin/intel-gpu-device-plugin.spec
@@ -2,17 +2,13 @@ Name:           intel-gpu-device-plugin
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
 Version:        0.32.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Intel GPU device plugin manifests and container images for k3s Kubernetes cluster.
 License:        Apache-2.0
 URL:            https://github.com/intel/intel-device-plugins-for-kubernetes
 Source0:        https://github.com/intel/intel-device-plugins-for-kubernetes/archive/refs/tags/v%{version}.tar.gz#/%{name}-v%{version}.tar.gz
-# Source1 is a pre-built container image tarball for the Intel gpu device plugin.
-# to avoid building container images as part of the RPM build process, 
-# the required image is built locally in advance and included as a tarball.
-# With `docker build` and `docker save` 
-# and uploaded to the source package repository after is has been tested locally.
-Source1:        %{name}-image-v%{version}.tar
+# Generate image tar.zst by running `docker save <image> | zstd -T0 -16 -f --long=25 > intel-gpu-device-plugin-image-<version>.tar.zst`
+Source1:        %{name}-image-v%{version}.tar.zst
 Requires:       k3s
 
 %description
@@ -26,12 +22,12 @@ mkdir -p %{buildroot}%{_sharedstatedir}/rancher/k3s/server/manifests/00-intel-gp
 mkdir -p %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/00-intel-gpu
 
 # Install the pre-pulled image tarball and manifest
-install -m 0644 %{SOURCE1} %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/00-intel-gpu/intel-gpu-plugin.tar
+install -m 0644 %{SOURCE1} %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/00-intel-gpu/intel-gpu-plugin.tar.zst
 install -m 0644 ./deployments/gpu_plugin/base/intel-gpu-plugin.yaml %{buildroot}%{_sharedstatedir}/rancher/k3s/server/manifests/00-intel-gpu/
 
 %files
 %{_sharedstatedir}/rancher/k3s/server/manifests/00-intel-gpu/intel-gpu-plugin.yaml
-%{_sharedstatedir}/rancher/k3s/agent/images/00-intel-gpu/intel-gpu-plugin.tar
+%{_sharedstatedir}/rancher/k3s/agent/images/00-intel-gpu/intel-gpu-plugin.tar.zst
 
 %changelog
 * Tue Jun 17 2025 Krishnamurthy Jambur <krishna.j.murthy@intel.com> - 0.32.1-1

--- a/SPECS/k3s-calico/k3s-calico.signatures.json
+++ b/SPECS/k3s-calico/k3s-calico.signatures.json
@@ -1,5 +1,8 @@
 {
     "Signatures": {
-        "k3s-calico-3.30.1.tar.gz": "fea217f0af51f7b2741520e8c9336cce411f6feebf338f0028b3925efc472784"
+        "k3s-calico-v3.30.1.tar.gz": "3040a1d313bafd30e4e2dea24c2155c8d1afbe3c6e961e0a4a52482d12b32490",
+        "k3s-calico-cni-image-v3.30.1.tar.zst": "c32d54f624fdb00da83fd98678fc1c98d45e5ff11fb15e1dc1d541796d065afb",
+        "k3s-calico-node-image-v3.30.1.tar.zst": "30ca801397d17102e5acb044aa829b62242d8e4035a1dd9726590d24d1c12219",
+        "k3s-calico-controllers-image-v3.30.1.tar.zst": "c7d31fbbe696cdc8be9d65569da1858b3e15e12caf9d096b28471c1e7871cfd8"
     }
 }

--- a/SPECS/k3s-calico/k3s-calico.spec
+++ b/SPECS/k3s-calico/k3s-calico.spec
@@ -51,6 +51,10 @@ install -m 644 %{SOURCE3} %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/image
 %{_sharedstatedir}/rancher/k3s/agent/images/00-calico/calico-kube-controllers.tar.zst
 
 %changelog
+* Mon Jun 24 2025 Eoghan Lawless <eoghan.lawless@intel.com> - 3.30.1-2
+- Update Source0 from release to source tarball
+- Add sources for zstd-compressed images replacing the uncompressed release images
+
 * Mon Jun 09 2025 Julia Okuniewska <julia.okuniewska@intel.com> - 3.30.1-1
 - Initial Edge Microvisor Toolkit import from the source project (license: same as "License" tag).
 - License verified.

--- a/SPECS/k3s-calico/k3s-calico.spec
+++ b/SPECS/k3s-calico/k3s-calico.spec
@@ -1,6 +1,6 @@
 Name:           k3s-calico
 Version:        3.30.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Calico manifests and container images for k3s kubernetes cluster.
 
 License:        Apache-2.0
@@ -8,7 +8,10 @@ Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
 
 URL:            https://github.com/projectcalico/calico
-Source0:        https://github.com/projectcalico/calico/releases/download/v%{version}/release-v%{version}.tgz#/%{name}-%{version}.tar.gz
+Source0:        https://github.com/projectcalico/calico/archive/refs/tags/v%{version}.tar.gz#/%{name}-v%{version}.tar.gz
+Source1:        %{name}-cni-image-v%{version}.tar.zst
+Source2:        %{name}-node-image-v%{version}.tar.zst
+Source3:        %{name}-controllers-image-v%{version}.tar.zst
 
 BuildArch:      noarch
 
@@ -16,7 +19,7 @@ BuildArch:      noarch
 This package provides Calico manifests and container images for k3s kubernetes cluster.
 
 %prep
-%setup -q -n release-v%{version}
+%setup -q -n calico-%{version}
 
 %build
 # No build steps required
@@ -33,18 +36,18 @@ install -m 644 ./manifests/calico.yaml %{buildroot}%{_sharedstatedir}/rancher/k3
 # docker.io/calico/node:v3.30.1
 # docker.io/calico/kube-controllers:v3.30.1
 
-install -m 644 ./images/calico-cni.tar %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/00-calico/
-install -m 644 ./images/calico-node.tar %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/00-calico/
-install -m 644 ./images/calico-kube-controllers.tar %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/00-calico/
+install -m 644 %{SOURCE1} %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/00-calico/calico-cni.tar.zst
+install -m 644 %{SOURCE2} %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/00-calico/calico-node.tar.zst
+install -m 644 %{SOURCE3} %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/00-calico/calico-kube-controllers.tar.zst
 
 
 %files
 %dir %{_sharedstatedir}/rancher/k3s/server/manifests/00-calico
 %dir %{_sharedstatedir}/rancher/k3s/agent/images/00-calico
 %{_sharedstatedir}/rancher/k3s/server/manifests/00-calico/calico.yaml
-%{_sharedstatedir}/rancher/k3s/agent/images/00-calico/calico-cni.tar
-%{_sharedstatedir}/rancher/k3s/agent/images/00-calico/calico-node.tar
-%{_sharedstatedir}/rancher/k3s/agent/images/00-calico/calico-kube-controllers.tar
+%{_sharedstatedir}/rancher/k3s/agent/images/00-calico/calico-cni.tar.zst
+%{_sharedstatedir}/rancher/k3s/agent/images/00-calico/calico-node.tar.zst
+%{_sharedstatedir}/rancher/k3s/agent/images/00-calico/calico-kube-controllers.tar.zst
 
 %changelog
 * Mon Jun 09 2025 Julia Okuniewska <julia.okuniewska@intel.com> - 3.30.1-1

--- a/SPECS/k3s-calico/k3s-calico.spec
+++ b/SPECS/k3s-calico/k3s-calico.spec
@@ -9,6 +9,7 @@ Distribution:   Edge Microvisor Toolkit
 
 URL:            https://github.com/projectcalico/calico
 Source0:        https://github.com/projectcalico/calico/archive/refs/tags/v%{version}.tar.gz#/%{name}-v%{version}.tar.gz
+# Generate tar.zst images by running `docker save <image> | zstd -T0 -16 -f --long=25 > <image>.tar.zst`
 Source1:        %{name}-cni-image-v%{version}.tar.zst
 Source2:        %{name}-node-image-v%{version}.tar.zst
 Source3:        %{name}-controllers-image-v%{version}.tar.zst

--- a/SPECS/k3s-multus-cni/k3s-multus-cni.signatures.json
+++ b/SPECS/k3s-multus-cni/k3s-multus-cni.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "k3s-multus-cni-image-v4.2.1.tar.gz": "c83bf4e47cde7326694e0e941bc1f49625bd912c2d23c38c304b7656af19b08c",
+  "k3s-multus-cni-image-v4.2.1.tar.zst": "3aaf0a7a893b6de8312ddd64695a5b57c2f79ea45b47eee7708bc0c61bb51219",
   "k3s-multus-cni-v4.2.1.tar.gz": "7c940f03099b9c9741bea641028859fe4e3e8f657ef922a9cb1c87ebd5e1fe28"
  }
 }

--- a/SPECS/k3s-multus-cni/k3s-multus-cni.spec
+++ b/SPECS/k3s-multus-cni/k3s-multus-cni.spec
@@ -9,7 +9,7 @@ Distribution:   Edge Microvisor Toolkit
 
 URL:            https://github.com/k8snetworkplumbingwg/multus-cni
 Source0:        https://github.com/k8snetworkplumbingwg/multus-cni/archive/refs/tags/v%{version}.tar.gz#/%{name}-v%{version}.tar.gz
-# Generate image tar by running `docker save ghcr.io/k8snetworkplumbingwg/multus-cni:<version> | zstd -T0 -16 -f --long=25 > k3s-multus-cni-<version>.tar.zst`
+# Generate image tar.zst by running `docker save ghcr.io/k8snetworkplumbingwg/multus-cni:<version> | zstd -T0 -16 -f --long=25 > k3s-multus-cni-<version>.tar.zst`
 Source1:        %{name}-image-v%{version}.tar.zst
 Patch0:         multus-daemonset.patch
 Requires:       k3s

--- a/SPECS/k3s-multus-cni/k3s-multus-cni.spec
+++ b/SPECS/k3s-multus-cni/k3s-multus-cni.spec
@@ -1,6 +1,6 @@
 Name:           k3s-multus-cni
 Version:        4.2.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Multus manifests and container images for k3s kubernetes cluster.
 
 License:        Apache-2.0
@@ -9,8 +9,8 @@ Distribution:   Edge Microvisor Toolkit
 
 URL:            https://github.com/k8snetworkplumbingwg/multus-cni
 Source0:        https://github.com/k8snetworkplumbingwg/multus-cni/archive/refs/tags/v%{version}.tar.gz#/%{name}-v%{version}.tar.gz
-# Generate image tar by running `docker save ghcr.io/k8snetworkplumbingwg/multus-cni:<version> | gzip > k3s-multus-cni-<version>.tar.gz`
-Source1:        %{name}-image-v%{version}.tar.gz
+# Generate image tar by running `docker save ghcr.io/k8snetworkplumbingwg/multus-cni:<version> | zstd -T0 -16 -f --long=25 > k3s-multus-cni-<version>.tar.zst`
+Source1:        %{name}-image-v%{version}.tar.zst
 Patch0:         multus-daemonset.patch
 Requires:       k3s
 
@@ -36,13 +36,13 @@ install -m 644 ./deployments/multus-daemonset.yml %{buildroot}%{_sharedstatedir}
 # Multus manifest uses 1 image
 # 
 # ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1
-install -m 644 %{SOURCE1} %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/10-multus/multus-cni.tar.gz
+install -m 644 %{SOURCE1} %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/images/10-multus/multus-cni.tar.zst
 
 %files
 %dir %{_sharedstatedir}/rancher/k3s/server/manifests/10-multus
 %dir %{_sharedstatedir}/rancher/k3s/agent/images/10-multus
 %{_sharedstatedir}/rancher/k3s/server/manifests/10-multus/multus-daemonset.yml
-%{_sharedstatedir}/rancher/k3s/agent/images/10-multus/multus-cni.tar.gz
+%{_sharedstatedir}/rancher/k3s/agent/images/10-multus/multus-cni.tar.zst
 
 %changelog
 * Mon Jun 23 2025 Hyunsun Moon <hyunsun.moon@intel.com> - 4.2.1-2

--- a/SPECS/k3s-multus-cni/k3s-multus-cni.spec
+++ b/SPECS/k3s-multus-cni/k3s-multus-cni.spec
@@ -45,6 +45,9 @@ install -m 644 %{SOURCE1} %{buildroot}%{_sharedstatedir}/rancher/k3s/agent/image
 %{_sharedstatedir}/rancher/k3s/agent/images/10-multus/multus-cni.tar.zst
 
 %changelog
+* Mon Jun 24 2025 Eoghan Lawless <eoghan.lawless@intel.com> - 4.2.1-3
+- Update Source1 to use a zstd-compressed image
+
 * Mon Jun 23 2025 Hyunsun Moon <hyunsun.moon@intel.com> - 4.2.1-2
 - Update patch to configure additional cni bin path for k3s
 - Compress multus cni image in the package

--- a/SPECS/yq/yq.spec
+++ b/SPECS/yq/yq.spec
@@ -9,7 +9,7 @@ Group:          Applications/System
 URL:            https://mikefarah.gitbook.io/yq
 Source0:        https://github.com/mikefarah/yq/archive/refs/tags/v%{version}.tar.gz#/%{name}-v%{version}.tar.gz
 Source1:        %{name}-vendor-v%{version}.tar.gz
-BuildRequires:  golang
+BuildRequires:  golang-1.24.1
 
 %description
 yq is a portable command-line YAML, JSON, XML, CSV, TOML and properties processor.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8362,7 +8362,7 @@
         "other": {
           "name": "k3s-calico",
           "version": "3.30.1",
-          "downloadUrl": "https://github.com/projectcalico/calico/releases/download/v3.30.1/release-v3.30.1.tgz"
+          "downloadUrl": "https://github.com/projectcalico/calico/archive/refs/tags/v3.30.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
Updated k3s-multus, k3s-calico and intel-gpu-device-plugin image sources to be zstd compressed.
Compression command used:
`zstd --no-progress -T0 -16 -f --long=25 <image tar> -o <output tar.zst>`

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
None

#### How Has This Been Tested? <!-- REQUIRED -->
Packages built locally
