### PR TITLE
Increase desktop virtualization image /opt partition size to 9G

### DIFF
--- a/toolkit/imageconfigs/edge-image-desktop-virtualization-dev.json
+++ b/toolkit/imageconfigs/edge-image-desktop-virtualization-dev.json
@@ -2,7 +2,7 @@
     "Disks": [
         {
             "PartitionTableType": "gpt",
-            "MaxSize": 9216,
+            "MaxSize": 13312,
             "Artifacts": [
                 {
                     "Name": "edge-readonly-dv-dev",

--- a/toolkit/imageconfigs/edge-image-desktop-virtualization.json
+++ b/toolkit/imageconfigs/edge-image-desktop-virtualization.json
@@ -2,7 +2,7 @@
     "Disks": [
         {
             "PartitionTableType": "gpt",
-            "MaxSize": 9216,
+            "MaxSize": 13312,
             "Artifacts": [
                 {
                     "Name": "edge-readonly-dv",


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Increase desktop virtualization image /opt partition size to 9G to cater for container images after loading.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Build edge-image-desktop-virtualization-dev.json and boot dut.
guest@EdgeMicrovisorToolkit [ ~ ]$ lsblk
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
nvme1n1     259:0    0 232.9G  0 disk
├─nvme1n1p1 259:1    0   299M  0 part /boot/efi
├─nvme1n1p2 259:2    0   3.7G  0 part /
└─nvme1n1p3 259:3    0     9G  0 part /etc/edge-node/metrics
                                      /var/edge-node/pua
                                      /etc/intel_manageability.conf_bak
                                      /etc/intel_manageability.conf
                                      /etc/dispatcher.environment
                                      /var/log/inbm-update-log.log
                                      /var/log/inbm-update-status.log
                                      /var/lib/dispatcher
                                      /etc/intel-manageability
                                      /var/cache/manageability
                                      /var/intel-manageability
                                      /var/lib/rancher
                                      /etc/default
                                      /etc/lvm/backup
                                      /etc/lvm/archive
                                      /etc/kubernetes
                                      /etc/cni
                                      /etc/netplan
                                      /etc/rancher
                                      /etc/sysconfig
                                      /etc/cloud
                                      /etc/udev
                                      /etc/systemd
                                      /etc/ssh
                                      /etc/pki
                                      /etc/machine-id
                                      /etc/intel_edge_node
                                      /etc/hosts
                                      /etc/environment
                                      /etc/fstab
                                      /home
                                      /opt
guest@EdgeMicrovisorToolkit [ ~ ]$ df /
Filesystem     1K-blocks    Used Available Use% Mounted on
/dev/nvme1n1p2   3697136 2774604    714252  80% /
guest@EdgeMicrovisorToolkit [ ~ ]$ df /opt
Filesystem     1K-blocks    Used Available Use% Mounted on
/dev/nvme1n1p3   9233884 1082172   7661064  13% /opt

