### PR TITLE
[DOCS] unifying CODEOWNERS for documentation port3.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
-* @open-edge-platform/edge-microvisor-toolkit-maintain 
+* @open-edge-platform/edge-microvisor-toolkit-maintain
 
-/docs @open-edge-platform/edge-microvisor-toolkit-docs-write
+# documentation content
+/docs @open-edge-platform/open-edge-platform-docs-write
+README.md @open-edge-platform/open-edge-platform-docs-write


### PR DESCRIPTION
#### Merge Checklist 
- [x] Ready to merge

#### Description
port: https://github.com/open-edge-platform/edge-microvisor-toolkit/pull/261
Adjusting CODEOWNERS for easier documentation adjustments and group management (one documentation group across the organization).