### PR TITLE
Added the 'wireless-regdb' package to fix for regulatory.db file

### DIFF
--- a/toolkit/imageconfigs/full.json
+++ b/toolkit/imageconfigs/full.json
@@ -14,7 +14,8 @@
                 "packagelists/intel-rdt.json",
                 "packagelists/drtm.json",
                 "packagelists/virt-guest-packages.json",
-                "packagelists/docker.json"
+                "packagelists/docker.json",
+		"packagelists/intel-wireless.json"
             ],
             "KernelCommandLine": {
                 "SELinux": "permissive"
@@ -44,7 +45,8 @@
                 "packagelists/intel-gpu-base.json",
                 "packagelists/drtm.json",
                 "packagelists/virt-guest-packages.json",
-                "packagelists/docker.json"
+	        "packagelists/docker.json",
+		"packagelists/intel-wireless.json"
             ],
             "KernelCommandLine": {
                 "SELinux": "permissive"
@@ -74,7 +76,8 @@
                 "packagelists/intel-gpu-base-rt.json",
                 "packagelists/intel-rdt.json",
                 "packagelists/drtm.json",
-                "packagelists/virt-guest-packages.json"
+                "packagelists/virt-guest-packages.json",
+                "packagelists/intel-wireless.json"
             ],
             "KernelCommandLine": {
                 "SELinux": "permissive"


### PR DESCRIPTION
Added the 'wireless-regdb' package to remove regulatory.db file warning shown in kernel logs for docker, k3s and RT-kernel images.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
Added the 'wireless-regdb' package to fix for regulatory.db file issue.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
No

#### How Has This Been Tested? <!-- REQUIRED -->
Generated ISO and installed selecting "RT-Kernel+Docker+k3s"option.

![rpviewer (4)](https://github.com/user-attachments/assets/fe547dc7-8a74-48f9-ae3c-203695f1cc26)
 
