### PR TITLE
 Fix disk configuration loading for graphical EFI boot order setup

### DIFF
--- a/SPECS/calamares/0001-Change-users-module-to-use-attended_config.json.patch
+++ b/SPECS/calamares/0001-Change-users-module-to-use-attended_config.json.patch
@@ -1,0 +1,26 @@
+From eaa962545716175e3915305e398394d32ef4eac6 Mon Sep 17 00:00:00 2001
+From: kintalix jayanth <jayanthx.kintali@intel.com>
+Date: Tue, 2 Sep 2025 13:01:02 +0530
+Subject: [PATCH] Change users module to use attended_config.json
+
+Signed-off-by: kintalix jayanth <jayanthx.kintali@intel.com>
+---
+ src/modules/users/Config.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/modules/users/Config.cpp b/src/modules/users/Config.cpp
+index d11fe40..c3ec978 100644
+--- a/src/modules/users/Config.cpp
++++ b/src/modules/users/Config.cpp
+@@ -978,7 +978,7 @@ Config::createJobs() const
+     // j = new SetupGroupsJob( this );
+     // jobs.append( Calamares::job_ptr( j ) );
+ 
+-    const std::string confPath = "/etc/calamares/unattended_config.json";
++    const std::string confPath = "/etc/calamares/attended_config.json";
+     j = new MarinerconfJob( m_hostname, loginName(), userPassword(), confPath );
+     jobs.append( Calamares::job_ptr( j ) );
+ 
+-- 
+2.34.1
+

--- a/SPECS/calamares/calamares.spec
+++ b/SPECS/calamares/calamares.spec
@@ -7,7 +7,7 @@ Summary:        Installer from a live CD/DVD/USB to disk
 # https://github.com/calamares/calamares/issues/1051
 Name:           calamares
 Version:        3.3.1
-Release:        13%{?dist}
+Release:        14%{?dist}
 License:        GPLv3+
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -60,6 +60,7 @@ Patch8:          change-completion-from-second-to-minute.patch
 Patch9:          ui_redesign.patch
 Patch10:         c69e229be0be9bd7a033776ebe3bec63206b8151.patch
 Patch11:         change-wording-in-welcomepage.patch
+Patch12:         0001-Change-users-module-to-use-attended_config.json.patch
 # Compilation tools
 BuildRequires:  cmake
 BuildRequires:  extra-cmake-modules
@@ -160,6 +161,7 @@ mv %{SOURCE56} data/images/wait.png
 %patch -P 9 -p1
 %patch -P 10 -p1
 %patch -P 11 -p1
+%patch -P 12 -p1
 
 %build
 %cmake_kf \
@@ -237,6 +239,9 @@ install -p -m 644 %{SOURCE21} %{buildroot}%{_sysconfdir}/calamares/settings.conf
 %{_libdir}/libcalamaresui.so
 
 %changelog
+* Tue Sep 01 2025 kintalix jayanth <kintalix.jayanth@intel.com> - 3.3.1-14
+-  switched config path to attended_config.json instead of unattended_config.json
+
 * Tue June 17 2025 Tan Jia Yong <jia.yong.tan@intel.com> - 3.3.1-13
 - Change welcome page wording.
 

--- a/toolkit/tools/liveinstaller/liveinstaller.go
+++ b/toolkit/tools/liveinstaller/liveinstaller.go
@@ -180,6 +180,7 @@ func runBootEntryCreationCommand(installDetails installationDetails) (err error)
 	}
 	bootPartIdx, bootPart := cfg.GetBootPartition()
 	bootDisk := cfg.GetDiskContainingPartition(bootPart)
+	logger.Log.Infof("Selected boot partition index %d on disk %s", bootPartIdx+1, bootDisk.TargetDisk.Value)
 
 	commandArgs := []string{
 		"-c",                            // Create a new bootnum and place it in the beginning of the boot order
@@ -309,14 +310,14 @@ func findMouseHandlers() (handlers string, err error) {
 	return
 }
 
-func calamaresInstall(templateConfigFile string, args imagerArguments) (err error) {
+func calamaresInstall(templateConfigFile string, args imagerArguments) (result configuration.Config, err error) {
 	const (
 		squashErrors = false
 		calamaresDir = "/etc/calamares"
 	)
 
 	args.emitProgress = true
-	args.configFile = filepath.Join(calamaresDir, "unattended_config.json")
+	args.configFile = filepath.Join(calamaresDir, "attended_config.json")
 
 	launchScript := filepath.Join(calamaresDir, "mariner-install.sh")
 	skuDir := filepath.Join(calamaresDir, "edgemicrovisortoolkit-skus")
@@ -352,9 +353,24 @@ func calamaresInstall(templateConfigFile string, args imagerArguments) (err erro
 		return
 	}
 
-	return shell.ExecuteLive(squashErrors, "calamares", "-platform", "linuxfb")
-}
+	logger.Log.Infof("Executing Calamares installer")
+	err = shell.ExecuteLive(squashErrors, "calamares", "-platform", "linuxfb")
+	if err != nil {
+		return
+	}
 
+	// Load the configuration file produced by Calamares
+	tempConfig, err := configuration.Load(args.configFile)
+	if err != nil {
+		return
+	}
+
+	for i := range tempConfig.SystemConfigs {
+		tempConfig.SystemConfigs[i].BootType = bootType
+	}
+
+	return tempConfig, nil
+}
 func generateCalamaresLaunchScript(launchScriptPath string, args imagerArguments) (err error) {
 	const executionPerm = 0755
 
@@ -418,6 +434,7 @@ func terminalUIAttendedInstall(templateConfigFile string, args imagerArguments) 
 	}
 
 	args.configFile = filepath.Join(args.buildDir, configFileName)
+	var calamaresdiskCfg configuration.Config
 	attendedInstaller, err := attendedinstaller.New(templateConfig,
 		// Terminal-UI based installation
 		func(cfg configuration.Config, progress chan int, status chan string) (err error) {
@@ -426,7 +443,12 @@ func terminalUIAttendedInstall(templateConfigFile string, args imagerArguments) 
 
 		// Calamares based installation
 		func() (err error) {
-			return calamaresInstall(templateConfigFile, args)
+			cfg, err := calamaresInstall(templateConfigFile, args)
+			if err == nil && len(cfg.SystemConfigs) > 0 {
+				calamaresdiskCfg = cfg
+				return
+			}
+			return
 		})
 
 	if err != nil {
@@ -434,7 +456,11 @@ func terminalUIAttendedInstall(templateConfigFile string, args imagerArguments) 
 	}
 
 	finalConfig, installationQuit, err := attendedInstaller.Run()
-	installDetails.finalConfig = finalConfig
+	if len(calamaresdiskCfg.SystemConfigs) > 0 || len(calamaresdiskCfg.Disks) > 0 {
+		installDetails.finalConfig = calamaresdiskCfg
+	} else {
+		installDetails.finalConfig = finalConfig
+	}
 	installDetails.installationQuit = installationQuit
 	return
 }


### PR DESCRIPTION
- Updated calamaresInstall() to use attended_config.json, return the full
- configuration, and load the final system config produced by Calamares while
- ensuring BootType is set. Added logging for selected boot partition and
- installer execution. terminalUIAttendedInstall() was updated to prioritize
-  Calamares’ config when available, ensuring accurate disk/system setup.
 


#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description 
For reference to [ITEP-69717](https://jira.devtools.intel.com/browse/ITEP-69717): These changes improve the installer’s integration with Calamares. The calamaresInstall() function now loads and returns the complete configuration instead of just an error, switching to attended_config.json and ensuring BootType is set for all system configs. Additional logs were added to make boot partition selection and installer execution clearer. In terminalUIAttendedInstall(), a new variable captures the Calamares config and overrides the terminal-based config when valid, so the installer always prefers the most accurate disk and system configuration

On EMT OS, the graphical installer does not currently set the EFI boot entry after installation, whereas the terminal installer does. This appears to be due to missing steps in the graphical installation process. The PR resolves this by ensuring the EFI boot order is correctly updated once the graphical installation is complete.

#### Any Newly Introduced Dependencies
No

#### How Has This Been Tested? 
Tested locally.