### PR TITLE
[DOCS] codeowners extension for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @open-edge-platform/edge-microvisor-toolkit-maintain
 
 # documentation content
-/docs @open-edge-platform/open-edge-platform-docs-write
-README.md @open-edge-platform/open-edge-platform-docs-write
+/docs/    @open-edge-platform/open-edge-platform-docs-write @open-edge-platform/edge-microvisor-toolkit-maintain
+README.md @open-edge-platform/open-edge-platform-docs-write @open-edge-platform/edge-microvisor-toolkit-maintain


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
- [] Ready to merge

#### Description <!-- REQUIRED -->
Add more granular rules to codeowners, so that the docs team can approve PRs for docs and readme's but at the same time, it does not block component owners from approving and merging PRs with changes to docs.
