### PR TITLE
[EMB] Rm unrequired conf files in etc/cmdline.d

### DIFF
--- a/toolkit/imageconfigs/scripts/setup-bootkit-image.sh
+++ b/toolkit/imageconfigs/scripts/setup-bootkit-image.sh
@@ -52,6 +52,8 @@ cd /tmp/initramfs
 echo "$pprefix: inside $(pwd)"
 echo "$pprefix: after copy $(du -h /tmp/initramfs)"
 echo "$pprefix: check cmdline.d $(ls etc/cmdline.d)"
+rm -f etc/cmdline.d/*
+echo "$pprefix: check cmdline.d after cleanup $(ls etc/cmdline.d)"
 echo "$pprefix: check cmdline.d contents $(cat etc/cmdline.d/95root-dev.conf)"
 echo 'root=tmpfs rootflags=size=1G,mode=0755' > etc/cmdline.d/95root-dev.conf
 echo "$pprefix: check cmdline.d contents after edit $(cat etc/cmdline.d/95root-dev.conf)"


### PR DESCRIPTION
Remove unrequired conf files in etc/cmdline.d when setting up rootfs image for Edge Microvisor Bootkit build.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Update edge microvisor bootkit image setup to clean up /etc/cmdline.d to remove all unnecessary conf files to not impact boot command line.

<!-- Fixes # (issue) -->
additional cmdline conf files added in /etc/cmdline.d from EMT baseline is preventing Edge microvisor bootkit vmlinuz/initramfs boot to login.

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
build edge-image-bootkit.json and run qemu from generated initramfs/vmlinuz to ensure able to boot to login.
/home/user/sfonn/run-initrd-vm.sh
[FAILED] Failed to start device-discovery.service - Device Discovery Agent.
[FAILED] Failed to start tink-worker.service - Tinkerbell Worker Service.

Welcome to Edge Microvisor Bootkit 3.0 (x86_64) - (ttyS0)
localhost login:

