### PR TITLE
Update the link to EMT-S on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or build your own system, using the existing infrastructure.
 
 The currently published versions are:
 
-* [Edge Microvisor Toolkit Standalone Node (immutable)](https://edgesoftwarecatalog.intel.com/details/?microserviceType=recipe&microserviceNameForUrl=edge-microvisor-toolkit-standalone-node)
+* [Edge Microvisor Toolkit Standalone Node (immutable)](https://github.com/open-edge-platform/edge-microvisor-toolkit-standalone-node)
 * [Edge Microvisor Toolkit Developer Node with or without real time extensions (mutable)](https://edgesoftwarecatalog.intel.com/details/?microserviceType=recipe&microserviceNameForUrl=edge--microvisor-toolkit-development-node)
 * [Edge Microvisor Toolkit (immutable) - Available in Edge Manageability Framework](https://github.com/open-edge-platform/edge-manageability-framework)
 * [Edge Microvisor Toolkit with real time extensions (immutable) - Available in Edge Manageability Framework](https://github.com/open-edge-platform/edge-manageability-framework)


### PR DESCRIPTION
Replacing the EMT-S link from ESC to https://github.com/open-edge-platform/edge-microvisor-toolkit-standalone-node


