### PR TITLE
Add daemon.json with overlay2 to fix container startup issue

### DIFF
--- a/SPECS/moby-engine/daemon.json
+++ b/SPECS/moby-engine/daemon.json
@@ -1,0 +1,4 @@
+{
+  "data-root": "/opt/docker-data",
+  "storage-driver": "overlay2"
+}

--- a/SPECS/moby-engine/moby-engine.signatures.json
+++ b/SPECS/moby-engine/moby-engine.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
+  "daemon.json": "b4995b275fd2a7ffe2533360832f81b452c38b90e0bd1126d8af6e02fc6ed4a2",
   "docker.service": "b150b3ce0947a65c655ed09dfe4e48b7464c60542f9f9902330288bbf87af38e",
   "docker.socket": "51a06786cae46bc63b7314c25d0bd5bb2e676120d80874b99e35bf60d0b0ffa8",
   "moby-engine-25.0.3.tar.gz": "4cdb516f5d6f5caf8b3bcf93c2962277ba727cfd2d1620176a3bb0cf153b3590"

--- a/SPECS/moby-engine/moby-engine.spec
+++ b/SPECS/moby-engine/moby-engine.spec
@@ -3,16 +3,17 @@
 Summary: The open-source application container engine
 Name:    moby-engine
 Version: 25.0.3
-Release: 14%{?dist}
+Release: 15%{?dist}
 License: ASL 2.0
 Group:   Tools/Container
 URL: https://mobyproject.org
-Vendor: Microsoft Corporation
-Distribution: Azure Linux
+Vendor: Intel Corporation
+Distribution: Edge Microvisor Toolkit
 
 Source0: https://github.com/moby/moby/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1: docker.service
 Source2: docker.socket
+Source3: daemon.json
 
 Patch0:  CVE-2022-2879.patch
 Patch1:  enable-docker-proxy-libexec-search.patch
@@ -104,10 +105,15 @@ mkdir -p %{buildroot}%{_unitdir}
 install -p -m 644 %{SOURCE1} %{buildroot}%{_unitdir}/docker.service
 install -p -m 644 %{SOURCE2} %{buildroot}%{_unitdir}/docker.socket
 
+mkdir -p -m 755 %{buildroot}%{_sysconfdir}/docker
+install -p -m 644 %{SOURCE3} %{buildroot}%{_sysconfdir}/docker/daemon.json
+
 %post
 if ! grep -q "^docker:" /etc/group; then
     groupadd --system docker
 fi
+mkdir -p /opt/docker-data
+chmod 0700 /opt/docker-data
 
 %preun
 %systemd_preun docker.service
@@ -119,10 +125,15 @@ fi
 %license LICENSE NOTICE
 %{_bindir}/dockerd
 %{_libexecdir}/docker-proxy
+%dir %{_sysconfdir}/docker
+%config(noreplace) %{_sysconfdir}/docker/daemon.json
 %{_sysconfdir}/*
 %{_unitdir}/*
 
 %changelog
+* Tue Nov 04 2025 Polmoorx Shiva Kumar <polmoorx.shiva.kumar@intel.com> - 25.0.3-15
+- Add daemon.json with overlay2 to fix container startup issue
+
 * Mon Sep 8 2025 Lee Chee Yang <chee.yang.lee@intel.com> - 25.0.3-14
 - merge from Azure Linux 3.0.20250910-3.0.
 - Patch CVE-2024-51744


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
On EMT OS, when we tried to start Docker, it failed because the default overlay2 storage driver requires a writable, overlay-compatible filesystem, but /var/lib/docker resides under /var, which on EMT OS can be mounted as read-only or which isn’t compatible with overlay operations. This prevented Docker from launching. To fix this, we configured Docker to store its data in /opt/docker-data, a persistent and writable location that supports overlay2, by adding a daemon.json file and updating the RPM spec to create the required directories, install the configuration, and safely migrate any existing data from /var/lib/docker using rsync. With this change, Docker now starts and runs reliably on both RT and non-RT EMT OS, using a stable and compatible storage location.
<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies  <!-- REQUIRED -->
No
#### How Has This Been Tested? <!-- REQUIRED -->
Tested manually.