### PR TITLE
(security) golang: bump Go version to 1.24.4-1 (#13967)

### DIFF
--- a/SPECS/golang/golang.signatures.json
+++ b/SPECS/golang/golang.signatures.json
@@ -3,7 +3,7 @@
     "go.20230802.5.src.tar.gz": "56b9e0e0c3c13ca95d5efa6de4e7d49a9d190eca77919beff99d33cd3fa74e95",
     "go.20240206.2.src.tar.gz": "7982e0011aa9ab95fd0530404060410af4ba57326d26818690f334fdcb6451cd",
     "go1.22.12-20250211.4.src.tar.gz": "e1cc3bff8fdf1f24843ffc9f0eaddfd344eb40fd9ca0d9ba2965165be519eeb7",
-    "go1.24.3-20250506.3.src.tar.gz": "8c3b4b0a849e128c1c6d7efd3206f37b7bbfd3df5b019f47cae85bb4f85222f2",
+    "go1.24.4-20250605.5.src.tar.gz": "a54803e23684bfc6b0acc8ce3a793c3666dcad1a323b5561158c63741367c3a2",
     "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
   }
 }

--- a/SPECS/golang/golang.spec
+++ b/SPECS/golang/golang.spec
@@ -1,6 +1,6 @@
 %global goroot          %{_libdir}/golang
 %global gopath          %{_datadir}/gocode
-%global ms_go_filename  go1.24.3-20250506.3.src.tar.gz
+%global ms_go_filename  go1.24.4-20250605.5.src.tar.gz
 %global ms_go_revision  1
 %ifarch aarch64
 %global gohostarch      arm64
@@ -14,7 +14,7 @@
 %define __find_requires %{nil}
 Summary:        Go
 Name:           golang
-Version:        1.24.3
+Version:        1.24.4
 Release:        1%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
@@ -160,6 +160,9 @@ fi
 %{_bindir}/*
 
 %changelog
+* Fri Jun 06 2025 bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com> - 1.24.4-1
+- Bump version to 1.24.4-1
+
 * Wed May 07 2025 bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com> - 1.24.3-1
 - Bump version to 1.24.3-1
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4740,8 +4740,8 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.24.1",
-          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.24.1-1/go1.24.1-20250304.4.src.tar.gz"
+          "version": "1.24.4",
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.24.4-1/go1.24.4-20250605.5.src.tar.gz"
         }
       }
     },


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Cherry-pick golang 1.24.4 from AzureLinux to EMT for support EMF agents golang req of 1.24.4.
Update cgmanifest.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Built golang 1.24.4-1 rpm and also built with new EMF agent requiring 1.24.4 and build and booted non-RT dev image with new rpms.
