### PR TITLE
Upgrade intel-opencl-clang and spirv-llvm-translator

### DIFF
--- a/SPECS/intel-opencl-clang/intel-opencl-clang.signatures.json
+++ b/SPECS/intel-opencl-clang/intel-opencl-clang.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "intel-opencl-clang-470cf001.tar.gz": "fa410e0b4cc5b3fc3262e3b6aaace3543207a20ecd004f48dfec9a970f1fe4e2"
+  "intel-opencl-clang-81cf510c.tar.gz": "8c628b886b0eeba8df4474ac6e7ed103a37ddca6203ccf7c2a9b948b87e8333c"
  }
 }

--- a/SPECS/intel-opencl-clang/intel-opencl-clang.spec
+++ b/SPECS/intel-opencl-clang/intel-opencl-clang.spec
@@ -1,10 +1,9 @@
-%global llvm_compat 14
-%global commit 470cf0018e1ef6fc92eda1356f5f31f7da452abc
+%global commit 81cf510c707c19ae5215763b824f80c25916fe5e
 %global shortcommit %(c=%{commit}; echo ${c:0:8})
 
 Name:           intel-opencl-clang
-Version:        140
-Release:        2%{?dist}
+Version:        180
+Release:        1%{?dist}
 Summary:        Library to compile OpenCL C kernels to SPIR-V modules
 License:        Apache-2.0 WITH LLVM-exception OR NCSA
 Vendor:         Intel Corporation
@@ -13,12 +12,12 @@ URL:            https://github.com/intel/opencl-clang
 Source0:        %{url}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
 
 BuildRequires:  cmake
-BuildRequires:  clang%{?llvm_compat}
+BuildRequires:  clang
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  make
-BuildRequires:  llvm%{?llvm_compat}-devel
-BuildRequires:  clang%{?llvm_compat}-devel
+BuildRequires:  llvm-devel
+BuildRequires:  clang-devel
 BuildRequires:  spirv-llvm-translator-devel
 BuildRequires:  spirv-llvm-translator
 BuildRequires:  zlib-devel
@@ -52,12 +51,15 @@ developing against %{name}
 
 %files devel
 %{_libdir}/libopencl-clang.so
-%{_includedir}/cclang/common_clang.h
+%{_includedir}/cclang/opencl_clang.h
 %{_includedir}/cclang/opencl-c.h
 %{_includedir}/cclang/opencl-c-base.h
 %{_includedir}/cclang/module.modulemap
 
 %changelog
+* Tue Aug 01 2025 Jayanth kintali<jayanthx.kintali@intel.com> - 180-1
+- Upgrade the intel-opencl-clang component version from 140 to 180
+
 * Tue Dec 24 2024 Naveen Saini <naveen.kumar.saini@intel.com> - 140-2
 - Updated initial changelog entry having fedora version and license info.
 

--- a/SPECS/spirv-llvm-translator/spirv-llvm-translator.signatures.json
+++ b/SPECS/spirv-llvm-translator/spirv-llvm-translator.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "spirv-llvm-translator-v14.0.3.tar.gz": "c225f6929e5433c303c0f8f63a8e201322363c6817ebb1368ddb068279131ba7"
+  "spirv-llvm-translator-v18.1.1.tar.gz": "c1c7aee4ea23a6a1089bb7f7bad198c28ada65c5b7671434562fe0241d8674d6"
  }
 }

--- a/SPECS/spirv-llvm-translator/spirv-llvm-translator.spec
+++ b/SPECS/spirv-llvm-translator/spirv-llvm-translator.spec
@@ -1,8 +1,6 @@
-%global llvm_compat 14
-
 Name:           spirv-llvm-translator
-Version:        14.0.3
-Release:        2%{?dist}
+Version:        18.1.1
+Release:        1%{?dist}
 Summary:        LLVM to SPIRV Translator
 License:        NCSA
 Vendor:         Intel Corporation
@@ -13,7 +11,7 @@ BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  cmake
 BuildRequires:  ninja-build
-BuildRequires:  llvm%{llvm_compat}-devel
+BuildRequires:  llvm-devel
 BuildRequires:  spirv-headers-devel
 BuildRequires:  spirv-tools-devel
 BuildRequires:  zlib-devel
@@ -71,6 +69,9 @@ This package contains the standalone llvm to spirv tool.
 %{_libdir}/pkgconfig/LLVMSPIRVLib.pc
 
 %changelog
+* Tue Aug 01 2025 Jayanth kintali<jayanthx.kintali@intel.com> - 18.1.1-1
+- Upgrade the spirv-llvm-translator component version from 14.0.3s to 18.1.1
+
 * Tue Dec 24 2024 Naveen Saini <naveen.kumar.saini@intel.com> - 14.0.3-2
 - Updated initial changelog entry having fedora version and license info.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7601,8 +7601,8 @@
         "type": "other",
         "other": {
           "name": "intel-opencl-clang",
-          "version": "140",
-          "downloadUrl": "https://github.com/intel/opencl-clang/archive/470cf0018e1ef6fc92eda1356f5f31f7da452abc/intel-opencl-clang-.tar.gz"
+          "version": "180",
+          "downloadUrl": "https://github.com/intel/opencl-clang/archive/81cf510c707c19ae5215763b824f80c25916fe5e/intel-opencl-clang-81cf510c.tar.gz"
         }
       }
     },
@@ -28946,8 +28946,8 @@
         "type": "other",
         "other": {
           "name": "spirv-llvm-translator",
-          "version": "14.0.3",
-          "downloadUrl": "https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v14.0.3/spirv-llvm-translator-v14.0.3.tar.gz"
+          "version": "18.1.1",
+          "downloadUrl": "https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v18.1.1/spirv-llvm-translator-v18.1.1.tar.gz"
         }
       }
     },


### PR DESCRIPTION
- Updated intel-opencl-clang to commit 81cf510c, version 180.
- Updated spirv-llvm-translator to version 18.1.1
- Renamed header file common_clang.h to opencl_clang.h in intel-opencl-clang.
- Updated cgmanifest.json.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [X] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
Upgrade intel-opencl-clang and spirv-llvm-translator 

#### Any Newly Introduced Dependencies
NA

#### How Has This Been Tested? <!-- REQUIRED -->
Tested manually