### PR TITLE
Update to use system-installed spdlog for intel-xpu-smi

### DIFF
--- a/SPECS/intel-xpu-smi/intel-xpu-smi.spec
+++ b/SPECS/intel-xpu-smi/intel-xpu-smi.spec
@@ -1,19 +1,20 @@
 Summary:        Intel XPU System Management Interface
 Name:           intel-xpu-smi
 Version:        1.2.39
-Release:        4%{?dist}
+Release:        5%{?dist}
 License:        MIT
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
 URL:            https://github.com/intel/xpumanager
 Source0:        https://github.com/intel/xpumanager/archive/refs/tags/V%{version}.tar.gz#/%{name}-%{version}.tar.gz
-
+Patch0:         system-installed-spdlog.patch
 BuildRequires:  cmake
 BuildRequires:  glibc-static >= 2.38-10%{?dist}
 BuildRequires:  libpciaccess-devel
 BuildRequires:  intel-level-zero-devel
 BuildRequires:  intel-metee-devel
 BuildRequires:  intel-igsc-devel
+BuildRequires:  spdlog-devel
 
 Requires:       intel-level-zero
 Requires:       intel-metee
@@ -37,7 +38,7 @@ Requires:   %{name} = %{version}-%{release}
 The %{name}-devel package contains libraries and header files for %{name}.
 
 %prep
-%autosetup -n xpumanager-%{version}
+%autosetup -p1 -n xpumanager-%{version}
 
 %build
 mkdir build
@@ -46,6 +47,7 @@ cmake .. \
     -DCMAKE_INSTALL_PREFIX=%{_prefix} \
     -DCMAKE_INSTALL_LIBDIR=%{_libdir} \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DSYSTEM_SPDLOG=ON \
     -DDAEMONLESS=ON \
     -DCPACK_GENERATOR=RPM
 make %{?_smp_mflags}
@@ -75,6 +77,9 @@ make install DESTDIR=%{buildroot}
 %{_libdir}/xpu-smi/resources/*
 
 %changelog
+* Wed Aug 11 2025 Polmoorx Shiva Kumar <polmoorx.shiva.kumar@intel.com> - 1.2.39-5
+- Patch for system installed spdlog
+
 * Thu jul 24 2025 Lee Chee Yang <chee.yang.lee@intel.com> - 1.2.39-4
 - rebuild for glibc bump
 

--- a/SPECS/intel-xpu-smi/system-installed-spdlog.patch
+++ b/SPECS/intel-xpu-smi/system-installed-spdlog.patch
@@ -1,0 +1,38 @@
+From fb5aca1522d8c9846d207a6863f7fa2690e201bd Mon Sep 17 00:00:00 2001
+From: Polmoorx Shiva Kumar <polmoorx.shiva.kumar@intel.com>
+Date: Mon, 11 Aug 2025 21:38:00 +0530
+Subject: [PATCH] spdlog: Use system library if requested
+
+---
+ CMakeLists.txt | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5b251ee..b12c55b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -71,10 +71,20 @@ add_definitions(-DLOADER_VERSION_PATCH=${PROJECT_VERSION_PATCH})
+ 
+ message(STATUS "CMAKE_PROJECT_VERSION: ${CMAKE_PROJECT_VERSION}")
+ 
++if(SYSTEM_SPDLOG)
++	find_package(spdlog CONFIG)
++	if(spdlog_FOUND)
++		message(STATUS "System spdlog found.")
++	else()
++		message(FATAL_ERROR "SYSTEM_SPDLOG specified but spdlog wasn't found.")
++	endif()
++else()
++   add_subdirectory(third_party/spdlog)
++endif()
++
+ if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/third_party/googletest)
+   add_subdirectory(third_party/googletest)
+ endif()
+-add_subdirectory(third_party/spdlog)
+ add_subdirectory(third_party/hwloc)
+ add_subdirectory(third_party/pcm/pcm-iio-gpu)
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Added a patch to enable using the system-provided spdlog library when requested. This avoids bundling a copy, keeps things up to date and ensures consistency with spdlog updates across the system.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Added a patch to enable using the system-provided spdlog library
when requested. This avoids bundling a copy, keeps things up to date
and ensures consistency with spdlog updates across the system.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->
No
#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Manually tested
