### PR TITLE
net-tools: add ether-wake utility build and install support

### DIFF
--- a/SPECS/net-tools/ether-wake.8
+++ b/SPECS/net-tools/ether-wake.8
@@ -1,0 +1,81 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH ETHER-WAKE 8 "March 31, 2003" "Scyld"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+ether-wake \- A tool to send a Wake-On-LAN "Magic Packet"
+.SH SYNOPSIS
+.B ether-wake
+.RI [ options ] " Host-ID"
+.SH DESCRIPTION
+This manual page documents the usage of the
+.B ether-wake
+command.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invoke bold face and italics, 
+.\" respectively.
+\fBether-wake\fP is a program that generates and transmits a Wake-On-LAN 
+(WOL) "Magic Packet", used for restarting machines that have been
+soft-powered-down (ACPI D3-warm state). It generates the standard
+AMD Magic Packet format, optionally with a password included.  The
+single required parameter is a station (MAC) address or a host ID that can
+be translated to a MAC address by an
+.BR ethers (5)
+database specified in
+.BR nsswitch.conf (5)
+.
+.SH OPTIONS
+\fBether-wake\fP needs a single dash (´-´) in front of options.
+A summary of options is included below.
+.TP
+.B \-b
+Send the wake-up packet to the broadcast address.
+.TP
+.B \-D
+Increase the Debug Level.
+.TP
+.B \-i ifname
+Use interface ifname instead of the default "eth0".
+.TP
+.B \-p passwd
+Append a four or six byte password to the packet. Only a few adapters
+need or support this. A six byte password may be specified in Ethernet hex
+format (00:22:44:66:88:aa) or four byte dotted decimal (192.168.1.1) format.
+A four byte password must use the dotted decimal format.
+ 
+.TP
+.B \-V
+Show the program version information.
+ 
+.SH EXIT STATUS
+This program returns 0 on success.
+A permission failures (e.g. run as a non-root user) results in an exit
+status of 2.  Unrecognized or invalid parameters result in an exit
+status of 3.  Failure to retrieve network interface information or send
+a packet will result in an exit status of 1.
+ 
+.SH SEE ALSO
+.BR arp (8).
+.br
+.SH SECURITY
+On some non-Linux systems dropping root capability allows the process to be
+dumped, traced or debugged.
+If someone traces this program, they get control of a raw socket.
+Linux handles this safely, but beware when porting this program.
+.SH AUTHOR
+The ether-wake program was written by Donald Becker at Scyld Computing
+Corporation for use with the Scyld(\*(Tm) Beowulf System.

--- a/SPECS/net-tools/ether-wake.c
+++ b/SPECS/net-tools/ether-wake.c
@@ -1,0 +1,392 @@
+/* ether-wake.c: Send a magic packet to wake up sleeping machines. */
+ 
+static char version_msg[] =
+"ether-wake.c: v1.09 11/12/2003 Donald Becker, http://www.scyld.com/";
+static char brief_usage_msg[] =
+"usage: ether-wake [-i <ifname>] [-p aa:bb:cc:dd[:ee:ff]] 00:11:22:33:44:55\n"
+"   Use '-u' to see the complete set of options.\n";
+static char usage_msg[] =
+"usage: ether-wake [-i <ifname>] [-p aa:bb:cc:dd[:ee:ff]] 00:11:22:33:44:55\n"
+"\n"
+"	This program generates and transmits a Wake-On-LAN (WOL)\n"
+"	\"Magic Packet\", used for restarting machines that have been\n"
+"	soft-powered-down (ACPI D3-warm state).\n"
+"	It currently generates the standard AMD Magic Packet format, with\n"
+"	an optional password appended.\n"
+"\n"
+"	The single required parameter is the Ethernet MAC (station) address\n"
+"	of the machine to wake or a host ID with known NSS 'ethers' entry.\n"
+"	The MAC address may be found with the 'arp' program while the target\n"
+"	machine is awake.\n"
+"\n"
+"	Options:\n"
+"		-b	Send wake-up packet to the broadcast address.\n"
+"		-D	Increase the debug level.\n"
+"		-i ifname	Use interface IFNAME instead of the default 'eth0'.\n"
+"		-p <pw>		Append the four or six byte password PW to the packet.\n"
+"					A password is only required for a few adapter types.\n"
+"					The password may be specified in ethernet hex format\n"
+"					or dotted decimal (Internet address)\n"
+"		-p 00:22:44:66:88:aa\n"
+"		-p 192.168.1.1\n";
+ 
+/*
+	This program generates and transmits a Wake-On-LAN (WOL) "Magic Packet",
+	used for restarting machines that have been soft-powered-down
+	(ACPI D3-warm state).  It currently generates the standard AMD Magic Packet
+	format, with an optional password appended.
+ 
+	This software may be used and distributed according to the terms
+	of the GNU Public License, incorporated herein by reference.
+	Contact the author for use under other terms.
+ 
+	This source file was originally part of the network tricks package, and
+	is now distributed to support the Scyld Beowulf system.
+	Copyright 1999-2003 Donald Becker and Scyld Computing Corporation.
+ 
+	The author may be reached as becker@scyld, or C/O
+	 Scyld Computing Corporation
+	 914 Bay Ridge Road, Suite 220
+	 Annapolis MD 21403
+ 
+  Notes:
+  On some systems dropping root capability allows the process to be
+  dumped, traced or debugged.
+  If someone traces this program, they get control of a raw socket.
+  Linux handles this safely, but beware when porting this program.
+ 
+  An alternative to needing 'root' is using a UDP broadcast socket, however
+  doing so only works with adapters configured for unicast+broadcast Rx
+  filter.  That configuration consumes more power.
+*/
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <ctype.h>
+#include <string.h>
+ 
+#if 0							/* Only exists on some versions. */
+#include <ioctls.h>
+#endif
+ 
+#include <sys/socket.h>
+ 
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <linux/if.h>
+ 
+#include <features.h>
+#if __GLIBC__ >= 2 && __GLIBC_MINOR >= 1
+#include <netpacket/packet.h>
+#include <net/ethernet.h>
+#else
+#include <asm/types.h>
+#include <linux/if_packet.h>
+#include <linux/if_ether.h>
+#endif
+#include <netdb.h>
+#include <netinet/ether.h>
+ 
+/* Grrr, no consistency between include versions.
+   Enable this if setsockopt() isn't declared with your library. */
+#if 0
+extern int setsockopt __P ((int __fd, int __level, int __optname,
+							__ptr_t __optval, int __optlen));
+#else				/* New, correct head files.  */
+#include <sys/socket.h>
+#endif
+ 
+u_char outpack[1000];
+int outpack_sz = 0;
+int debug = 0;
+u_char wol_passwd[6];
+int wol_passwd_sz = 0;
+ 
+static int opt_no_src_addr = 0, opt_broadcast = 0;
+ 
+static int get_dest_addr(const char *arg, struct ether_addr *eaddr);
+static int get_fill(unsigned char *pkt, struct ether_addr *eaddr);
+static int get_wol_pw(const char *optarg);
+ 
+int main(int argc, char *argv[])
+{
+	char *ifname = "eth0";
+	int one = 1;				/* True, for socket options. */
+	int s;						/* Raw socket */
+	int errflag = 0, verbose = 0, do_version = 0;
+	int perm_failure = 0;
+	int i, c, pktsize;
+#if defined(PF_PACKET)
+	struct sockaddr_ll whereto;
+#else
+	struct sockaddr whereto;	/* who to wake up */
+#endif
+	struct ether_addr eaddr;
+ 
+	while ((c = getopt(argc, argv, "bDi:p:uvV")) != -1)
+		switch (c) {
+		case 'b': opt_broadcast++;	break;
+		case 'D': debug++;			break;
+		case 'i': ifname = optarg;	break;
+		case 'p': get_wol_pw(optarg); break;
+		case 'u': printf(usage_msg); return 0;
+		case 'v': verbose++;		break;
+		case 'V': do_version++;		break;
+		case '?':
+			errflag++;
+		}
+	if (verbose || do_version)
+		printf("%s\n", version_msg);
+	if (errflag) {
+		fprintf(stderr, brief_usage_msg);
+		return 3;
+	}
+ 
+	if (optind == argc) {
+		fprintf(stderr, "Specify the Ethernet address as 00:11:22:33:44:55.\n");
+		return 3;
+	}
+ 
+	/* Note: PF_INET, SOCK_DGRAM, IPPROTO_UDP would allow SIOCGIFHWADDR to
+	   work as non-root, but we need SOCK_PACKET to specify the Ethernet
+	   destination address. */
+#if defined(PF_PACKET)
+	s = socket(PF_PACKET, SOCK_RAW, 0);
+#else
+	s = socket(AF_INET, SOCK_PACKET, SOCK_PACKET);
+#endif
+	if (s < 0) {
+		if (errno == EPERM)
+			fprintf(stderr, "ether-wake: This program must be run as root.\n");
+		else
+			perror("ether-wake: socket");
+		perm_failure++;
+	}
+	/* Don't revert if debugging allows a normal user to get the raw socket. */
+	setuid(getuid());
+ 
+	/* We look up the station address before reporting failure so that
+	   errors may be reported even when run as a normal user.
+	*/
+	if (get_dest_addr(argv[optind], &eaddr) != 0)
+		return 3;
+	if (perm_failure && ! debug)
+		return 2;
+ 
+	pktsize = get_fill(outpack, &eaddr);
+ 
+	/* Fill in the source address, if possible.
+	   The code to retrieve the local station address is Linux specific. */
+	if (! opt_no_src_addr) {
+		struct ifreq if_hwaddr;
+		unsigned char *hwaddr = if_hwaddr.ifr_hwaddr.sa_data;
+ 
+		strcpy(if_hwaddr.ifr_name, ifname);
+		if (ioctl(s, SIOCGIFHWADDR, &if_hwaddr) < 0) {
+			fprintf(stderr, "SIOCGIFHWADDR on %s failed: %s\n", ifname,
+					strerror(errno));
+			/* Magic packets still work if our source address is bogus, but
+			   we fail just to be anal. */
+			return 1;
+		}
+		memcpy(outpack+6, if_hwaddr.ifr_hwaddr.sa_data, 6);
+ 
+		if (verbose) {
+			printf("The hardware address (SIOCGIFHWADDR) of %s is type %d  "
+				   "%2.2x:%2.2x:%2.2x:%2.2x:%2.2x:%2.2x.\n", ifname,
+				   if_hwaddr.ifr_hwaddr.sa_family, hwaddr[0], hwaddr[1],
+				   hwaddr[2], hwaddr[3], hwaddr[4], hwaddr[5]);
+		}
+	}
+ 
+	if (wol_passwd_sz > 0) {
+		memcpy(outpack+pktsize, wol_passwd, wol_passwd_sz);
+		pktsize += wol_passwd_sz;
+	}
+ 
+	if (verbose > 1) {
+		printf("The final packet is: ");
+		for (i = 0; i < pktsize; i++)
+			printf(" %2.2x", outpack[i]);
+		printf(".\n");
+	}
+ 
+	/* This is necessary for broadcasts to work */
+	if (setsockopt(s, SOL_SOCKET, SO_BROADCAST, (char *)&one, sizeof(one)) < 0)
+		perror("setsockopt: SO_BROADCAST");
+ 
+#if defined(PF_PACKET)
+	{
+		struct ifreq ifr;
+		strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+		if (ioctl(s, SIOCGIFINDEX, &ifr) == -1) {
+			fprintf(stderr, "SIOCGIFINDEX on %s failed: %s\n", ifname,
+					strerror(errno));
+			return 1;
+		}
+		memset(&whereto, 0, sizeof(whereto));
+		whereto.sll_family = AF_PACKET;
+		whereto.sll_ifindex = ifr.ifr_ifindex;
+		/* The manual page incorrectly claims the address must be filled.
+		   We do so because the code may change to match the docs. */
+		whereto.sll_halen = ETH_ALEN;
+		memcpy(whereto.sll_addr, outpack, ETH_ALEN);
+ 
+	}
+#else
+	whereto.sa_family = 0;
+	strcpy(whereto.sa_data, ifname);
+#endif
+ 
+	if ((i = sendto(s, outpack, pktsize, 0, (struct sockaddr *)&whereto,
+					sizeof(whereto))) < 0)
+		perror("sendto");
+	else if (debug)
+		printf("Sendto worked ! %d.\n", i);
+ 
+#ifdef USE_SEND
+	if (bind(s, (struct sockaddr *)&whereto, sizeof(whereto)) < 0)
+		perror("bind");
+	else if (send(s, outpack, 100, 0) < 0)
+		perror("send");
+#endif
+#ifdef USE_SENDMSG
+	{
+		struct msghdr msghdr = { 0,};
+		struct iovec iovector[1];
+		msghdr.msg_name = &whereto;
+		msghdr.msg_namelen = sizeof(whereto);
+		msghdr.msg_iov = iovector;
+		msghdr.msg_iovlen = 1;
+		iovector[0].iov_base = outpack;
+		iovector[0].iov_len = pktsize;
+		if ((i = sendmsg(s, &msghdr, 0)) < 0)
+			perror("sendmsg");
+		else if (debug)
+			printf("sendmsg worked, %d (%d).\n", i, errno);
+	}
+#endif
+ 
+	return 0;
+}
+ 
+/* Convert the host ID string to a MAC address.
+   The string may be a
+	Host name
+    IP address string
+	MAC address string
+*/
+ 
+static int get_dest_addr(const char *hostid, struct ether_addr *eaddr)
+{
+	struct ether_addr *eap;
+ 
+	eap = ether_aton(hostid);
+	if (eap) {
+		*eaddr = *eap;
+		if (debug)
+			fprintf(stderr, "The target station address is %s.\n",
+					ether_ntoa(eaddr));
+	} else if (ether_hostton(hostid, eaddr) == 0) {
+		if (debug)
+			fprintf(stderr, "Station address for hostname %s is %s.\n",
+					hostid, ether_ntoa(eaddr));
+	} else {
+		(void)fprintf(stderr,
+					  "ether-wake: The Magic Packet host address must be "
+					  "specified as\n"
+					  "  - a station address, 00:11:22:33:44:55, or\n"
+					  "  - a hostname with a known 'ethers' entry.\n");
+		return -1;
+	}
+	return 0;
+}
+ 
+ 
+static int get_fill(unsigned char *pkt, struct ether_addr *eaddr)
+{
+	int offset, i;
+	unsigned char *station_addr = eaddr->ether_addr_octet;
+ 
+	if (opt_broadcast)
+		memset(pkt+0, 0xff, 6);
+	else
+		memcpy(pkt, station_addr, 6);
+	memcpy(pkt+6, station_addr, 6);
+	pkt[12] = 0x08;				/* Or 0x0806 for ARP, 0x8035 for RARP */
+	pkt[13] = 0x42;
+	offset = 14;
+ 
+	memset(pkt+offset, 0xff, 6);
+	offset += 6;
+ 
+	for (i = 0; i < 16; i++) {
+		memcpy(pkt+offset, station_addr, 6);
+		offset += 6;
+	}
+	if (debug) {
+		fprintf(stderr, "Packet is ");
+		for (i = 0; i < offset; i++)
+			fprintf(stderr, " %2.2x", pkt[i]);
+		fprintf(stderr, ".\n");
+	}
+	return offset;
+}
+ 
+static int get_wol_pw(const char *optarg)
+{
+	int passwd[6];
+	int byte_cnt;
+	int i;
+ 
+	byte_cnt = sscanf(optarg, "%2x:%2x:%2x:%2x:%2x:%2x",
+					  &passwd[0], &passwd[1], &passwd[2],
+					  &passwd[3], &passwd[4], &passwd[5]);
+	if (byte_cnt < 4)
+		byte_cnt = sscanf(optarg, "%d.%d.%d.%d",
+						  &passwd[0], &passwd[1], &passwd[2], &passwd[3]);
+	if (byte_cnt < 4) {
+		fprintf(stderr, "Unable to read the Wake-On-LAN password.\n");
+		return 0;
+	}
+	printf(" The Magic packet password is %2.2x %2.2x %2.2x %2.2x (%d).\n",
+		   passwd[0], passwd[1], passwd[2], passwd[3], byte_cnt);
+	for (i = 0; i < byte_cnt; i++)
+		wol_passwd[i] = passwd[i];
+	return wol_passwd_sz = byte_cnt;
+}
+ 
+#if 0
+{
+	to = (struct sockaddr_in *)&whereto;
+	to->sin_family = AF_INET;
+	if (inet_aton(target, &to->sin_addr)) {
+		hostname = target;
+	}
+	memset (&sa, 0, sizeof sa);
+	sa.sa_family = AF_INET;
+	strncpy (sa.sa_data, interface, sizeof sa.sa_data);
+	sendto (sock, buf, bufix + len, 0, &sa, sizeof sa);
+	strncpy (sa.sa_data, interface, sizeof sa.sa_data);
+#if 1
+	sendto (sock, buf, bufix + len, 0, &sa, sizeof sa);
+#else
+	bind (sock, &sa, sizeof sa);
+	connect();
+	send (sock, buf, bufix + len, 0);
+#endif
+}
+#endif
+ 
+
+/*
+ * Local variables:
+ *  compile-command: "gcc -O -Wall -o ether-wake ether-wake.c"
+ *  c-indent-level: 4
+ *  c-basic-offset: 4
+ *  c-indent-level: 4
+ *  tab-width: 4
+ * End:
+ */

--- a/SPECS/net-tools/net-tools.signatures.json
+++ b/SPECS/net-tools/net-tools.signatures.json
@@ -1,5 +1,7 @@
 {
  "Signatures": {
-  "net-tools-2.10.tar.xz": "b262435a5241e89bfa51c3cabd5133753952f7a7b7b93f32e08cb9d96f580d69"
+  "net-tools-2.10.tar.xz": "b262435a5241e89bfa51c3cabd5133753952f7a7b7b93f32e08cb9d96f580d69",
+  "ether-wake.c": "a20a6aa6f47ea5b5112b941a57c027b4438e50eed5838813f71baa441c8ddada",
+  "ether-wake.8": "514e1e7d5f04bf6bea3f4935626472a42331c4b28ebb641c1d46c6e5341955c1"
  }
 }

--- a/SPECS/net-tools/net-tools.spec
+++ b/SPECS/net-tools/net-tools.spec
@@ -1,19 +1,22 @@
 Summary:        Networking Tools
 Name:           net-tools
 Version:        2.10
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2+
 Vendor:         Microsoft Corporation
 Distribution:   Azure Linux
 Group:          System Environment/Base
 URL:            https://sourceforge.net/projects/net-tools/
 Source0:        https://downloads.sourceforge.net/project/%{name}/%{name}-%{version}.tar.xz
+Source1:        ether-wake.c
+Source2:        ether-wake.8
 Conflicts:      toybox
 Obsoletes:      inetutils
 Provides:       hostname = %{version}-%{release}
 
 %description
 The Net-tools package is a collection of programs for controlling the network subsystem of the Linux kernel.
+Now includes the ether-wake utility.
 
 %prep
 %autosetup -p1
@@ -30,12 +33,16 @@ sed -i -e 's|# HAVE_IP_TOOLS=0|HAVE_IP_TOOLS=1|g' \
        -e 's|# HAVE_MII=0|HAVE_MII=1|g' config.make
 sed -i 's|#include <netinet/ip.h>|//#include <netinet/ip.h>|g' iptunnel.c
 make
+# Build ether-wake
+gcc -O2 -Wall -o ether-wake %{SOURCE1}
 
 %install
 make BASEDIR=%{buildroot} install
+install -m0755 ether-wake %{buildroot}/sbin/ether-wake
+install -m0644 %{SOURCE2} %{buildroot}%{_mandir}/man8/ether-wake.8
 
-%post	-p /sbin/ldconfig
-%postun	-p /sbin/ldconfig
+%post   -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
 
 %files
 %defattr(-,root,root)
@@ -45,8 +52,13 @@ make BASEDIR=%{buildroot} install
 %{_mandir}/man1/*
 %{_mandir}/man5/*
 %{_mandir}/man8/*
+/sbin/ether-wake
+%{_mandir}/man8/ether-wake.8*
 
 %changelog
+* Tue Aug 19 2025 kintali Jayanth <jayanthx.kintali@intel.com> - 2.10-4
+- Added build and install support for ether-wake utility
+
 * Wed Sep 20 2023 Jon Slobodzian <joslobo@microsoft.com> - 2.10-3
 - Recompile with stack-protection fixed gcc version (CVE-2023-4039)
 


### PR DESCRIPTION
- Added ether-wake.c and ether-wake.8 as new sources
- Updated spec file to build ether-wake binary and install man page
- Installed ether-wake under /sbin and added man page under man8

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
[ITEP-74801](https://jira.devtools.intel.com/browse/ITEP-74801) : Requirement to add ether-wake tool into net-tools
Imported ether-wake.c and ether-wake.8 from Fedora f43 sources
Updated net-tools.spec to build the ether-wake binary
Installed binary under /sbin and man page under man8

#### Any Newly Introduced Dependencies
No

#### How Has This Been Tested? <!-- REQUIRED -->
Manually Tested