### PR TITLE
Fix: ISO boot failure caused by non-existent device UUID in dracut

### DIFF
--- a/toolkit/imageconfigs/packagelists/core-packages-image.json
+++ b/toolkit/imageconfigs/packagelists/core-packages-image.json
@@ -7,7 +7,6 @@
         "cronie-anacron",
         "logrotate",
         "core-packages-base-image",
-        "dracut-hostonly",
         "dracut-vrf",
         "dracut-systemd-cryptsetup",
         "initramfs",


### PR DESCRIPTION
In rare cases, dracut hostonly mode incorrectly include a non-existent device UUID in its boot-up wait list. This would cause dracut to wait indefinitely during boot, leading to a timeout and boot failure.

This patch resolves the issue by disabling the dracut hostonly mode in ISO. By doing so, dracut dynamically detects devices at boot time, eliminating the risk of using a fixed, and potentially non-existent, device list compiled during ISO installation.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
