### PR TITLE
Add Intel wifi firmware

### DIFF
--- a/SPECS/linux-firmware/linux-firmware.spec
+++ b/SPECS/linux-firmware/linux-firmware.spec
@@ -1,7 +1,7 @@
 Summary:        Linux Firmware
 Name:           linux-firmware
 Version:        20250509
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPL+ AND GPLv2+ AND MIT AND Redistributable, no modification permitted
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -83,12 +83,16 @@ cp -r i915 %{buildroot}%{_firmwarepath}
 cp -r xe %{buildroot}%{_firmwarepath}
 cp -r intel %{buildroot}%{_firmwarepath}
 cp iwlwifi-8000C-*.ucode %{buildroot}%{_firmwarepath}
+cp iwlwifi-9000-*.ucode %{buildroot}%{_firmwarepath}
+cp iwlwifi-9260-*.ucode %{buildroot}%{_firmwarepath}
 cp iwlwifi-so-a0-gf-a0-89.ucode %{buildroot}%{_firmwarepath}
 cp iwlwifi-so-a0-gf-a0.pnvm %{buildroot}%{_firmwarepath}
 cp iwlwifi-ma-b0-gf-a0-83.ucode %{buildroot}%{_firmwarepath}
 cp iwlwifi-ma-b0-gf-a0-86.ucode %{buildroot}%{_firmwarepath}
 cp iwlwifi-ma-b0-gf-a0-89.ucode %{buildroot}%{_firmwarepath}
 cp iwlwifi-ma-b0-gf-a0.pnvm %{buildroot}%{_firmwarepath}
+cp iwlwifi-ty-a0-gf-a0-89.ucode %{buildroot}%{_firmwarepath}
+cp iwlwifi-ty-a0-gf-a0.pnvm %{buildroot}%{_firmwarepath}
 
 %files
 %defattr(-,root,root)
@@ -150,6 +154,10 @@ cp iwlwifi-ma-b0-gf-a0.pnvm %{buildroot}%{_firmwarepath}
 %{_firmwarepath}/iwlwifi-ma-b0-gf-a0-86.ucode
 %{_firmwarepath}/iwlwifi-ma-b0-gf-a0-89.ucode
 %{_firmwarepath}/iwlwifi-ma-b0-gf-a0.pnvm
+%{_firmwarepath}/iwlwifi-ty-a0-gf-a0-89.ucode
+%{_firmwarepath}/iwlwifi-ty-a0-gf-a0.pnvm
+%{_firmwarepath}/iwlwifi-9000-*.ucode
+%{_firmwarepath}/iwlwifi-9260-*.ucode
 
 %files ice
 %defattr(-,root,root)
@@ -157,6 +165,9 @@ cp iwlwifi-ma-b0-gf-a0.pnvm %{buildroot}%{_firmwarepath}
 %{_firmwarepath}/intel/ice
 
 %changelog
+* Wed Sep 17 2025 Swee Yee Fonn <swee.yee.fonn@intel.com> - 20250509-2
+- Added iwlwifi package for Intel Wi-Fi AX210, Jefferson Peak, Thunder Peak.
+
 * Wed Jun 18 2025 Junxiao Chang <junxiao.chang@intel.com> - 20250509-1
 - Upgrade i915 GuC firmware version to 70.44.1.
 


### PR DESCRIPTION
Add linux firmware file for Intel Wi-Fi 6 AX210 and Jefferson/Thunderpeak module support

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Add linux firmware required for Intel Wi-Fi AX210/Jefferson Peak/Thunder Peak module support.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
build #861
Rebuilt linux-firmware rpms successfully.
Tested on DUT with AX210 wifi module firmware missing error is resolved.
