### PR TITLE
Add override.conf for systemd-journald service file.

### DIFF
--- a/SPECS/systemd/systemd-flush-umount-override.conf
+++ b/SPECS/systemd/systemd-flush-umount-override.conf
@@ -1,0 +1,6 @@
+# During shutdown,journald and umount.target are in conflict due to 
+# which mount failure logs are logged on console.
+# so adding below entry to systemd-journal-flush.service, to stop  
+# service, when system starts to unmount.
+[Unit]
+Conflicts=umount.target

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -19,6 +19,7 @@
   "systemd-journal-gatewayd.xml": "c2559b1244fb04f7fe214628daf09e12d431560b069b5ef346ace1ceddbe1bc9",
   "systemd-journal-remote.xml": "29a7ce0c161a99c0bb48ee6fd5def97d88c7d1c1dd776d4b4d93b6be0b6fdd9b",
   "systemd-udev-trigger-no-reload.conf": "e22c23fb4618a2021322c5b68fc16b872a27fe8a3edb42e8abec83896eba835a",
+  "systemd-flush-umount-override.conf": "d2f84e826df3d4936189b98cd698676eb86a7d13a21829e17db64987aea2f665",
   "sysusers.attr": "49cffe66a7a366272e9ebac212f50dc9bc8d55aa6b4ef092fc87cb230bd50520",
   "sysusers.generate-pre.sh": "6d503de2db2374125cb5c3b6034636514b58a38dcff193550768c3c49c6d7419",
   "sysusers.prov": "0dcc4b699030c11eccedb850d4d2c097ebdc725766e17db56f942ee445b93cf6",

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        29%{?dist}
+Release:        30%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -110,6 +110,7 @@ Source28:       99-yama-ptrace.conf
 Source29:       99-net-core-bpf-jit-harden.conf
 Source30:       99-kernel.conf
 Source31:       99-tcp-timestamps.conf
+Source32:       systemd-flush-umount-override.conf
 
 %if 0
 GIT_DIR=../../src/systemd/.git git format-patch-ab --no-signature -M -N v235..v235-stable
@@ -872,6 +873,9 @@ install -Dm0644 -t %{buildroot}%{_pkgdocdir}/ %{SOURCE28}
 # https://bugzilla.redhat.com/show_bug.cgi?id=1378974
 install -Dm0644 -t %{buildroot}%{system_unit_dir}/systemd-udev-trigger.service.d/ %{SOURCE10}
 
+# systemd-journal-flush.service override conf file
+install -Dm0644 -t %{buildroot}%{system_unit_dir}/systemd-journal-flush.service.d/ %{SOURCE32}
+
 # systemd-oomd default configuration
 install -Dm0644 -t %{buildroot}%{_prefix}/lib/systemd/oomd.conf.d/ %{SOURCE14}
 install -Dm0644 -t %{buildroot}%{system_unit_dir}/system.slice.d/ %{SOURCE15}
@@ -1237,6 +1241,10 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+* Tue Oct 17 2025 Basavaraj unniche <basavarajx.unniche@intel.com> - 255-30
+- Add systemd-flush-umount-override.conf to systemd-journal-flush 
+- .service to fix conflict issues during unmounting /var.
+
 * Fri May 30 2025 Ranjan Dutta <ranjan.dutta@intel.com> - 255-29
 - merge from Azure Linux 3.0.20250521-3.0
 - Bumping 'Release' tag to match the 'signed' version of the spec.


### PR DESCRIPTION
- During shutdown, there was conflict between journald and
- umount.target resulting error logs on console. so added a
- override.conf file to stop journald, when unmounting starts.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
 "Failed unmounting var.mount" error was logged during os reboot. on investigating, there was a conflict between journald and umount.target which is keeping /var busy during unmounting. Added override.conf to overcome this issue. Ref ITEP-27253.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
With changes, created raw image, loaded and on os reboot, not seeing any error log. Attached test results, to reported issue.
