### PR TITLE
Update MESA to 25.0.0 with SRIOV patches

### DIFF
--- a/SPECS/mesa/0001-iris-Add-renderonly-support.patch
+++ b/SPECS/mesa/0001-iris-Add-renderonly-support.patch
@@ -1,7 +1,7 @@
-From 1562270a76dbfa05a761f75e30089403f5b6d760 Mon Sep 17 00:00:00 2001
+From efe403fa0e4198c7b2a041c27c243d9c1685f969 Mon Sep 17 00:00:00 2001
 From: Tina Zhang <tina.zhang@intel.com>
 Date: Fri, 12 Mar 2021 12:57:41 +0800
-Subject: [PATCH 1/6] iris: Add renderonly support
+Subject: [PATCH 01/11] iris: Add renderonly support
 
 With this renderonly support, iris can work with other display device to
 show display. For example, in virtualization env, a virtio-gpu's display
@@ -13,29 +13,30 @@ v2: Add iris_resource_create_renderonly() helper function. (Kenneth)
 Signed-off-by: Tina Zhang <tina.zhang@intel.com>
 Signed-off-by: Mazlan, Hazwan Arif <hazwan.arif.mazlan@intel.com>
 ---
- src/gallium/drivers/iris/iris_resource.c      | 56 ++++++++++++++++++-
+ src/gallium/drivers/iris/iris_resource.c      | 57 ++++++++++++++++++-
  src/gallium/drivers/iris/iris_resource.h      |  1 +
  src/gallium/drivers/iris/iris_screen.c        |  2 +
  src/gallium/drivers/iris/iris_screen.h        |  1 +
  src/gallium/winsys/iris/drm/iris_drm_public.h |  5 ++
  src/gallium/winsys/iris/drm/iris_drm_winsys.c | 20 +++++++
  src/gallium/winsys/iris/drm/meson.build       |  8 ++-
- 7 files changed, 91 insertions(+), 2 deletions(-)
+ 7 files changed, 92 insertions(+), 2 deletions(-)
 
 diff --git a/src/gallium/drivers/iris/iris_resource.c b/src/gallium/drivers/iris/iris_resource.c
-index 68f5a43c3e0..2b0a42b451e 100644
+index 302afa9ae84..9359d98ec67 100644
 --- a/src/gallium/drivers/iris/iris_resource.c
 +++ b/src/gallium/drivers/iris/iris_resource.c
-@@ -53,6 +53,8 @@
+@@ -55,6 +55,9 @@
+ #include "intel/dev/intel_debug.h"
  #include "isl/isl.h"
  #include "drm-uapi/drm_fourcc.h"
- #include "drm-uapi/i915_drm.h"
++#include "drm-uapi/i915_drm.h"
 +#include "renderonly/renderonly.h"
 +#include "util/u_drm.h"
  
  enum modifier_priority {
     MODIFIER_PRIORITY_INVALID = 0,
-@@ -530,7 +532,12 @@ static void
+@@ -527,7 +530,12 @@ static void
  iris_resource_destroy(struct pipe_screen *screen,
                        struct pipe_resource *p_res)
  {
@@ -48,8 +49,8 @@ index 68f5a43c3e0..2b0a42b451e 100644
  
     if (p_res->target == PIPE_BUFFER)
        util_range_destroy(&res->valid_buffer_range);
-@@ -1199,6 +1206,43 @@ iris_resource_create_for_buffer(struct pipe_screen *pscreen,
-    return &res->base.b;
+@@ -1080,6 +1088,43 @@ iris_resource_image_is_pat_compressible(const struct iris_screen *screen,
+    return true;
  }
  
 +static struct pipe_resource *
@@ -92,7 +93,7 @@ index 68f5a43c3e0..2b0a42b451e 100644
  static struct pipe_resource *
  iris_resource_create_for_image(struct pipe_screen *pscreen,
                                 const struct pipe_resource *templ,
-@@ -1208,8 +1252,14 @@ iris_resource_create_for_image(struct pipe_screen *pscreen,
+@@ -1089,8 +1134,14 @@ iris_resource_create_for_image(struct pipe_screen *pscreen,
  {
     struct iris_screen *screen = (struct iris_screen *)pscreen;
     const struct intel_device_info *devinfo = screen->devinfo;
@@ -108,7 +109,7 @@ index 68f5a43c3e0..2b0a42b451e 100644
     if (!res)
        return NULL;
  
-@@ -1925,6 +1975,10 @@ iris_resource_get_handle(struct pipe_screen *pscreen,
+@@ -1893,6 +1944,10 @@ iris_resource_get_handle(struct pipe_screen *pscreen,
     case WINSYS_HANDLE_TYPE_KMS: {
        iris_gem_set_tiling(bo, &res->surf);
  
@@ -120,7 +121,7 @@ index 68f5a43c3e0..2b0a42b451e 100644
         * we export a GEM handle we must make sure it is valid in the DRM file
         * descriptor the caller is using (this is the FD given at screen
 diff --git a/src/gallium/drivers/iris/iris_resource.h b/src/gallium/drivers/iris/iris_resource.h
-index ffb50af9796..baa77c36518 100644
+index 4b946242636..7b1fa8366f2 100644
 --- a/src/gallium/drivers/iris/iris_resource.h
 +++ b/src/gallium/drivers/iris/iris_resource.h
 @@ -55,6 +55,7 @@ struct iris_format_info {
@@ -132,7 +133,7 @@ index ffb50af9796..baa77c36518 100644
     /**
      * The ISL surface layout information for this resource.
 diff --git a/src/gallium/drivers/iris/iris_screen.c b/src/gallium/drivers/iris/iris_screen.c
-index 74094b016ce..70838aa8a01 100644
+index 29c6ead4acb..514a2239026 100644
 --- a/src/gallium/drivers/iris/iris_screen.c
 +++ b/src/gallium/drivers/iris/iris_screen.c
 @@ -59,6 +59,7 @@
@@ -143,7 +144,7 @@ index 74094b016ce..70838aa8a01 100644
  
  #define genX_call(devinfo, func, ...)             \
     switch ((devinfo)->verx10) {                   \
-@@ -672,6 +673,7 @@ iris_screen_destroy(struct iris_screen *screen)
+@@ -596,6 +597,7 @@ iris_screen_destroy(struct iris_screen *screen)
     iris_bufmgr_unref(screen->bufmgr);
     disk_cache_destroy(screen->disk_cache);
     close(screen->winsys_fd);
@@ -152,10 +153,10 @@ index 74094b016ce..70838aa8a01 100644
  }
  
 diff --git a/src/gallium/drivers/iris/iris_screen.h b/src/gallium/drivers/iris/iris_screen.h
-index 1b22cb12a18..7bc0b996722 100644
+index d8e9edf45eb..6d23ca80748 100644
 --- a/src/gallium/drivers/iris/iris_screen.h
 +++ b/src/gallium/drivers/iris/iris_screen.h
-@@ -156,6 +156,7 @@ struct iris_address {
+@@ -171,6 +171,7 @@ struct iris_address {
  
  struct iris_screen {
     struct pipe_screen base;
@@ -218,12 +219,12 @@ index 15095e2d3fa..b414b64ef22 100644
 +   return &pscreen->base;
 +}
 diff --git a/src/gallium/winsys/iris/drm/meson.build b/src/gallium/winsys/iris/drm/meson.build
-index 3dcdc4a455e..cc9ea810756 100644
+index 1ed56b2e8cd..eeac906e6d3 100644
 --- a/src/gallium/winsys/iris/drm/meson.build
 +++ b/src/gallium/winsys/iris/drm/meson.build
-@@ -18,12 +18,18 @@
- # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- # SOFTWARE.
+@@ -1,13 +1,19 @@
+ # Copyright © 2017 Intel Corporation
+ # SPDX-License-Identifier: MIT
  
 +iris_drm_winsys_c_args = []
 +if with_gallium_kmsro
@@ -240,6 +241,7 @@ index 3dcdc4a455e..cc9ea810756 100644
    ],
 +  c_args : [iris_drm_winsys_c_args],
    gnu_symbol_visibility : 'hidden',
+   dependencies: idep_mesautil,
  )
 -- 
 2.34.1

--- a/SPECS/mesa/0001-vulkan-wsi-x11-fix-use-of-uninitialised-xfixes-regio.patch
+++ b/SPECS/mesa/0001-vulkan-wsi-x11-fix-use-of-uninitialised-xfixes-regio.patch
@@ -1,0 +1,40 @@
+From a61053e91940c1cf1256763681cdc76f269e305e Mon Sep 17 00:00:00 2001
+From: Dave Airlie <airlied@redhat.com>
+Date: Tue, 18 Feb 2025 17:00:42 +1000
+Subject: [PATCH] vulkan/wsi/x11: fix use of uninitialised xfixes region.
+
+If you are in the sw + no mit-shm support, we don't create the xfixes region,
+so don't try and use it in the same scenario.
+
+We are seeing some gtk4 apps crash with BadRegion reports due to this.
+
+Fixes: bbdf7e45b15f ("wsi/x11: Hook up KHR_incremental_present")
+---
+ src/vulkan/wsi/wsi_common_x11.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/vulkan/wsi/wsi_common_x11.c b/src/vulkan/wsi/wsi_common_x11.c
+index 8c364cd94dd..e8ebe4fb041 100644
+--- a/src/vulkan/wsi/wsi_common_x11.c
++++ b/src/vulkan/wsi/wsi_common_x11.c
+@@ -1804,13 +1804,17 @@ x11_queue_present(struct wsi_swapchain *anv_chain,
+ {
+    struct x11_swapchain *chain = (struct x11_swapchain *)anv_chain;
+    xcb_xfixes_region_t update_area = 0;
++   bool set_damage = damage ? true : false;
+ 
+    /* If the swapchain is in an error state, don't go any further. */
+    VkResult status = x11_swapchain_read_status_atomic(chain);
+    if (status < 0)
+       return status;
+ 
+-   if (damage && damage->pRectangles && damage->rectangleCount > 0 &&
++   if (chain->base.wsi->sw && !chain->has_mit_shm)
++      set_damage = false;
++
++   if (set_damage && damage->pRectangles && damage->rectangleCount > 0 &&
+       damage->rectangleCount <= MAX_DAMAGE_RECTS) {
+       xcb_rectangle_t *rects = chain->images[image_index].rects;
+ 
+-- 
+2.48.1

--- a/SPECS/mesa/0002-kmsro-Add-iris-renderonly-support.patch
+++ b/SPECS/mesa/0002-kmsro-Add-iris-renderonly-support.patch
@@ -1,7 +1,7 @@
-From b4b37f6d7d7460684576a53f53be61fe7b307ca1 Mon Sep 17 00:00:00 2001
+From 0426e1bbb3089e0728fa4d432463dacabaf037cf Mon Sep 17 00:00:00 2001
 From: Dongwon Kim <dongwon.kim@intel.com>
 Date: Fri, 19 Jan 2024 12:32:36 -0800
-Subject: [PATCH 3/3] kmsro: Add iris renderonly support
+Subject: [PATCH 02/11] kmsro: Add iris renderonly support
 
 Enable using iris for KMS renderonly.
 
@@ -23,10 +23,10 @@ Signed-off-by: Dongwon Kim <dongwon.kim@intel.com>
  8 files changed, 24 insertions(+), 5 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 6d10219f067..21da93d3387 100644
+index 1bd2bbc0a64..67243458b54 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -205,6 +205,7 @@ with_gallium_kmsro = system_has_kms_drm and [
+@@ -222,6 +222,7 @@ with_gallium_kmsro = system_has_kms_drm and [
    with_gallium_panfrost,
    with_gallium_v3d,
    with_gallium_vc4,
@@ -35,10 +35,10 @@ index 6d10219f067..21da93d3387 100644
  
  _vulkan_drivers = get_option('vulkan-drivers')
 diff --git a/src/gallium/auxiliary/pipe-loader/meson.build b/src/gallium/auxiliary/pipe-loader/meson.build
-index 7927515cf98..a1d9a51880f 100644
+index c828cab6169..98821c28050 100644
 --- a/src/gallium/auxiliary/pipe-loader/meson.build
 +++ b/src/gallium/auxiliary/pipe-loader/meson.build
-@@ -56,6 +56,9 @@ endif
+@@ -39,6 +39,9 @@ endif
  if with_gallium_asahi
    renderonly_drivers_c_args += '-DGALLIUM_ASAHI'
  endif
@@ -49,10 +49,10 @@ index 7927515cf98..a1d9a51880f 100644
  libpipe_loader_static = static_library(
    'pipe_loader_static',
 diff --git a/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c b/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
-index 055c637199d..e978c65cddb 100644
+index 985ace997bd..9df6c0ce31b 100644
 --- a/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
 +++ b/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
-@@ -295,6 +295,9 @@ pipe_loader_get_compatible_render_capable_device_fd(int kms_only_fd)
+@@ -331,6 +331,9 @@ pipe_loader_get_compatible_render_capable_device_fd(int kms_only_fd)
  #endif
  #if defined GALLIUM_VC4
        "vc4",
@@ -62,7 +62,7 @@ index 055c637199d..e978c65cddb 100644
  #endif
     };
  
-@@ -303,10 +306,12 @@ pipe_loader_get_compatible_render_capable_device_fd(int kms_only_fd)
+@@ -339,10 +342,12 @@ pipe_loader_get_compatible_render_capable_device_fd(int kms_only_fd)
     is_platform_device = (dev->type == PIPE_LOADER_DEVICE_PLATFORM);
     pipe_loader_release(&dev, 1);
  
@@ -76,10 +76,10 @@ index 055c637199d..e978c65cddb 100644
     /* For platform display-only devices, we try to find a render-capable device
      * on the platform bus and that should be compatible with the display-only
 diff --git a/src/gallium/auxiliary/target-helpers/drm_helper.h b/src/gallium/auxiliary/target-helpers/drm_helper.h
-index be44b8f71df..106bac7f7e1 100644
+index 3ddab30af49..f92a49e079b 100644
 --- a/src/gallium/auxiliary/target-helpers/drm_helper.h
 +++ b/src/gallium/auxiliary/target-helpers/drm_helper.h
-@@ -68,6 +68,7 @@ const struct drm_driver_descriptor descriptor_name = {         \
+@@ -69,6 +69,7 @@ const struct drm_driver_descriptor descriptor_name = {         \
  #undef GALLIUM_PANFROST
  #undef GALLIUM_LIMA
  #undef GALLIUM_ASAHI
@@ -87,9 +87,9 @@ index be44b8f71df..106bac7f7e1 100644
  #endif
  
  #ifdef GALLIUM_I915
-@@ -454,6 +455,9 @@ const driOptionDescription kmsro_driconf[] = {
- #ifdef GALLIUM_FREEDRENO
-       #include "freedreno/driinfo_freedreno.h"
+@@ -447,6 +448,9 @@ const driOptionDescription kmsro_driconf[] = {
+ #ifdef GALLIUM_PANFROST
+       #include "panfrost/driinfo_panfrost.h"
  #endif
 +#ifdef GALLIUM_IRIS
 +      #include "iris/driinfo_iris.h"
@@ -130,7 +130,7 @@ index b414b64ef22..bf6c5577c78 100644
        return NULL;
  
 diff --git a/src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c b/src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c
-index 3d14bce1ce7..87d39e08a95 100644
+index 259e876dc8b..46916e86722 100644
 --- a/src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c
 +++ b/src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c
 @@ -33,6 +33,7 @@
@@ -141,7 +141,7 @@ index 3d14bce1ce7..87d39e08a95 100644
  #include "xf86drm.h"
  
  #include "pipe/p_screen.h"
-@@ -119,6 +120,11 @@ struct pipe_screen *kmsro_drm_screen_create(int kms_fd,
+@@ -120,6 +121,11 @@ struct pipe_screen *kmsro_drm_screen_create(int kms_fd,
         */
        ro->create_for_resource = renderonly_create_gpu_import_for_resource;
        screen = vc4_drm_screen_create_renderonly(ro->gpu_fd, ro, config);
@@ -154,10 +154,10 @@ index 3d14bce1ce7..87d39e08a95 100644
     }
  
 diff --git a/src/loader/loader.c b/src/loader/loader.c
-index 4b8f532fe74..e1c0f83b846 100644
+index e8a9b76913a..0164acdd776 100644
 --- a/src/loader/loader.c
 +++ b/src/loader/loader.c
-@@ -154,8 +154,8 @@ loader_open_render_node_platform_device(const char * const drivers[],
+@@ -186,8 +186,8 @@ loader_open_render_node_platform_device(const char * const drivers[],
     for (i = 0; i < num_devices; i++) {
        device = devices[i];
  

--- a/SPECS/mesa/0003-iris-kmsro-use-ro-device-to-allocate-scanout-for-ren.patch
+++ b/SPECS/mesa/0003-iris-kmsro-use-ro-device-to-allocate-scanout-for-ren.patch
@@ -1,7 +1,8 @@
-From b05b95d83dc737b59bf9d20f04041d0270740b90 Mon Sep 17 00:00:00 2001
+From 8282ccb489d5d2172574b9f59b720c480024dfd7 Mon Sep 17 00:00:00 2001
 From: tchew6 <tong.liang.chew@intel.com>
 Date: Thu, 24 Jun 2021 13:20:53 +0800
-Subject: [PATCH 3/6] iris/kmsro: use ro device to allocate scanout for render
+Subject: [PATCH 03/11] iris/kmsro: use ro device to allocate scanout for
+ render
 
 Signed-off-by: Chew, Tong Liang <tong.liang.chew@intel.com>
 Signed-off-by: Mazlan, Hazwan Arif <hazwan.arif.mazlan@intel.com>
@@ -10,10 +11,10 @@ Signed-off-by: Mazlan, Hazwan Arif <hazwan.arif.mazlan@intel.com>
  1 file changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/src/gallium/drivers/iris/iris_resource.c b/src/gallium/drivers/iris/iris_resource.c
-index 2b0a42b451e..63245f4014a 100644
+index 9359d98ec67..0f1aef8678b 100644
 --- a/src/gallium/drivers/iris/iris_resource.c
 +++ b/src/gallium/drivers/iris/iris_resource.c
-@@ -1252,11 +1252,14 @@ iris_resource_create_for_image(struct pipe_screen *pscreen,
+@@ -1134,11 +1134,14 @@ iris_resource_create_for_image(struct pipe_screen *pscreen,
  {
     struct iris_screen *screen = (struct iris_screen *)pscreen;
     const struct intel_device_info *devinfo = screen->devinfo;
@@ -29,7 +30,7 @@ index 2b0a42b451e..63245f4014a 100644
     }
  
     struct iris_resource *res = iris_alloc_resource(pscreen, templ);
-@@ -1975,8 +1978,7 @@ iris_resource_get_handle(struct pipe_screen *pscreen,
+@@ -1944,8 +1947,7 @@ iris_resource_get_handle(struct pipe_screen *pscreen,
     case WINSYS_HANDLE_TYPE_KMS: {
        iris_gem_set_tiling(bo, &res->surf);
  

--- a/SPECS/mesa/0004-meson-version-update.patch
+++ b/SPECS/mesa/0004-meson-version-update.patch
@@ -1,7 +1,7 @@
-From b127c544c18af3d82a80dc873001d35a79e52233 Mon Sep 17 00:00:00 2001
+From 721755d43bea02e981385a84dfa093ee237427ae Mon Sep 17 00:00:00 2001
 From: "Chew, Tong Liang" <tong.liang.chew@intel.com>
 Date: Fri, 1 Apr 2022 12:47:43 +0800
-Subject: [PATCH 4/6] meson: version update
+Subject: [PATCH 04/11] meson: version update
 
 Signed-off-by: Chew, Tong Liang <tong.liang.chew@intel.com>
 ---
@@ -13,10 +13,10 @@ Signed-off-by: Chew, Tong Liang <tong.liang.chew@intel.com>
  5 files changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/src/egl/meson.build b/src/egl/meson.build
-index f387bde4bde..33d762e414e 100644
+index b6c803a85c4..fb638479d8a 100644
 --- a/src/egl/meson.build
 +++ b/src/egl/meson.build
-@@ -164,7 +164,7 @@ endif
+@@ -153,7 +153,7 @@ endif
  
  if not with_glvnd
    egl_lib_name = 'EGL' + get_option('egl-lib-suffix')
@@ -26,12 +26,12 @@ index f387bde4bde..33d762e414e 100644
  else
    egl_lib_name = 'EGL_@0@'.format(glvnd_vendor_name)
 diff --git a/src/gbm/meson.build b/src/gbm/meson.build
-index df65361aef7..0cc8650ba0c 100644
+index eaed028d049..07809d94793 100644
 --- a/src/gbm/meson.build
 +++ b/src/gbm/meson.build
-@@ -60,7 +60,7 @@ libgbm = shared_library(
-   link_with : libloader,
-   dependencies : [deps_gbm, dep_dl, dep_thread, idep_mesautil, idep_xmlconfig],
+@@ -34,7 +34,7 @@ libgbm = shared_library(
+   link_with : [libloader],
+   dependencies : [dep_libdrm, idep_xmlconfig],
    gnu_symbol_visibility : 'hidden',
 -  version : '1.0.0',
 +  version : '1.1.0',
@@ -39,10 +39,10 @@ index df65361aef7..0cc8650ba0c 100644
  )
  
 diff --git a/src/glx/meson.build b/src/glx/meson.build
-index 20f04742894..b051881e07f 100644
+index b52b91c5269..1f89b5a2573 100644
 --- a/src/glx/meson.build
 +++ b/src/glx/meson.build
-@@ -109,7 +109,7 @@ endif
+@@ -91,7 +91,7 @@ endif
  
  if not with_glvnd
    gl_lib_name = 'GL'
@@ -52,11 +52,11 @@ index 20f04742894..b051881e07f 100644
    gl_lib_name = 'GLX_@0@'.format(glvnd_vendor_name)
    gl_lib_version = '0.0.0'
 diff --git a/src/mapi/es1api/meson.build b/src/mapi/es1api/meson.build
-index 9ee093dd34e..e4bde547eeb 100644
+index 8a7c57e03d9..4010b65a26e 100644
 --- a/src/mapi/es1api/meson.build
 +++ b/src/mapi/es1api/meson.build
-@@ -56,7 +56,7 @@ libglesv1_cm = shared_library(
-   link_with : libglapi,
+@@ -39,7 +39,7 @@ libglesv1_cm = shared_library(
+   link_with : shared_glapi_lib,
    dependencies : [dep_thread, dep_libdrm, dep_m, dep_dl, idep_mesautilc11],
    soversion : host_machine.system() == 'windows' ? '' : '1',
 -  version : '1.1.0',
@@ -65,11 +65,11 @@ index 9ee093dd34e..e4bde547eeb 100644
    name_prefix : host_machine.system() == 'windows' ? 'lib' : [],  # always use lib, but avoid warnings on !windows
    install : true,
 diff --git a/src/mapi/es2api/meson.build b/src/mapi/es2api/meson.build
-index 7bce741984e..8c467878637 100644
+index afc5b95c856..922d06f2c73 100644
 --- a/src/mapi/es2api/meson.build
 +++ b/src/mapi/es2api/meson.build
-@@ -56,7 +56,7 @@ libgles2 = shared_library(
-   link_with : libglapi,
+@@ -39,7 +39,7 @@ libgles2 = shared_library(
+   link_with : shared_glapi_lib,
    dependencies : [dep_thread, dep_libdrm, dep_m, dep_dl, idep_mesautilc11],
    soversion : host_machine.system() == 'windows' ? '' : '2',
 -  version : '2.0.0',

--- a/SPECS/mesa/0005-Revert-Auto-enable-TLSDESC-support.patch
+++ b/SPECS/mesa/0005-Revert-Auto-enable-TLSDESC-support.patch
@@ -1,21 +1,19 @@
-From 65300d3c9c5f4b6facf1e30dd0343c8ce58cb79d Mon Sep 17 00:00:00 2001
-From: "Chew, Tong Liang" <tong.liang.chew@intel.com>
-Date: Tue, 8 Aug 2023 20:50:51 +0000
-Subject: [PATCH 6/6] Revert "Auto-enable TLSDESC support"
-
-This reverts commit 60d95c5d0feef4e4b2820a26c4708aff10f5730d
+From 40c3c14b3bb1926d5232cf138d841386a512e774 Mon Sep 17 00:00:00 2001
+From: "Mazlan, Hazwan Arif" <hazwan.arif.mazlan@intel.com>
+Date: Wed, 28 Aug 2024 16:38:31 +0800
+Subject: [PATCH 05/11] Revert "Auto-enable TLSDESC support"
 
 Signed-off-by: Chew, Tong Liang <tong.liang.chew@intel.com>
 ---
- meson.build | 34 ----------------------------------
- 1 file changed, 34 deletions(-)
+ meson.build | 42 ------------------------------------------
+ 1 file changed, 42 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 927e62255cf..2a04ea3bc4f 100644
+index 67243458b54..d6dd612165b 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -422,40 +422,6 @@ if with_platform_android and get_option('platform-sdk-version') >= 29
-   c_cpp_args += '-fno-emulated-tls'
+@@ -512,48 +512,6 @@ if with_platform_android and get_option('platform-sdk-version') >= 29
+   add_project_link_arguments('-Wl,-plugin-opt=-emulated-tls=0', language: ['c', 'cpp'])
  endif
  
 -# -mtls-dialect=gnu2 speeds up non-initial-exec TLS significantly but requires
@@ -32,23 +30,31 @@ index 927e62255cf..2a04ea3bc4f 100644
 -  # cross-compiling, but because this is just an optimization we can skip it
 -  if meson.is_cross_build() and not meson.can_run_host_binaries()
 -    warning('cannot auto-detect -mtls-dialect when cross-compiling, using compiler default')
+-  elif host_machine.system() == 'freebsd'
+-    warning('cannot use -mtls-dialect for FreeBSD, using compiler default')
 -  else
--    # -fpic to force dynamic tls, otherwise TLS relaxation defeats check
--    gnu2_test = cc.run('int __thread x; int main() { return x; }',
--                       args: ['-mtls-dialect=gnu2', '-fpic'],
--                       name: '-mtls-dialect=gnu2')
--    if gnu2_test.returncode() == 0 and (
--          # check for lld 13 bug: https://gitlab.freedesktop.org/mesa/mesa/-/issues/5665
--          host_machine.cpu_family() != 'x86_64' or
--          # get_linker_id misses LDFLAGS=-fuse-ld=lld: https://github.com/mesonbuild/meson/issues/6377
--          #cc.get_linker_id() != 'ld.lld' or
--          cc.links('''int __thread x; int y; int main() { __asm__(
--                "leaq x@TLSDESC(%rip), %rax\n"
--                "movq y@GOTPCREL(%rip), %rdx\n"
--                "call *x@TLSCALL(%rax)\n"); }''', name: 'split TLSDESC')
--          )
--      c_cpp_args += '-mtls-dialect=gnu2'
--    endif
+-    # The way to specify the TLSDESC dialect is architecture-specific.
+-    # We probe both because there is not a fallback guaranteed to work for all
+-    # future architectures.
+-    foreach tlsdesc_arg : ['-mtls-dialect=gnu2', '-mtls-dialect=desc']
+-      # -fpic to force dynamic tls, otherwise TLS relaxation defeats check
+-      tlsdesc_test = cc.run('int __thread x; int main() { return x; }',
+-                            args: [tlsdesc_arg, '-fpic'],
+-                            name: tlsdesc_arg)
+-      if tlsdesc_test.returncode() == 0 and (
+-            # check for lld 13 bug: https://gitlab.freedesktop.org/mesa/mesa/-/issues/5665
+-            host_machine.cpu_family() != 'x86_64' or
+-            # get_linker_id misses LDFLAGS=-fuse-ld=lld: https://github.com/mesonbuild/meson/issues/6377
+-            #cc.get_linker_id() != 'ld.lld' or
+-            cc.links('''int __thread x; int y; int main() { __asm__(
+-                  "leaq x@TLSDESC(%rip), %rax\n"
+-                  "movq y@GOTPCREL(%rip), %rdx\n"
+-                  "call *x@TLSCALL(%rax)\n"); }''', name: 'split TLSDESC')
+-            )
+-        c_cpp_args += tlsdesc_arg
+-        break
+-      endif
+-    endforeach
 -  endif
 -endif
 -

--- a/SPECS/mesa/0006-Revert-meson-ci-remove-dead-kmsro-option-in-gallium-.patch
+++ b/SPECS/mesa/0006-Revert-meson-ci-remove-dead-kmsro-option-in-gallium-.patch
@@ -1,0 +1,121 @@
+From f3835a998e0b56d04883b2cdaedfda6cc7408ab0 Mon Sep 17 00:00:00 2001
+From: "Kooran Paul, Princy" <princy.kooran.paul@intel.com>
+Date: Mon, 17 Mar 2025 14:38:45 +0800
+Subject: [PATCH 06/11] Revert "meson,ci: remove dead `kmsro` option in
+ `gallium-drivers`"
+
+This reverts commit 89863a050bea429d9574a307bc28953bb60accaf.
+---
+ .gitlab-ci/build/gitlab-ci.yml | 20 ++++++++++----------
+ meson_options.txt              |  2 +-
+ 2 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/.gitlab-ci/build/gitlab-ci.yml b/.gitlab-ci/build/gitlab-ci.yml
+index f9767c26c1a..6d51d087e48 100644
+--- a/.gitlab-ci/build/gitlab-ci.yml
++++ b/.gitlab-ci/build/gitlab-ci.yml
+@@ -183,7 +183,7 @@ debian-testing-msan:
+     # GLSL has some issues in sexpression reading.
+     # gtest has issues in its test initialization.
+     MESON_TEST_ARGS: "--suite glcpp --suite format"
+-    GALLIUM_DRIVERS: "freedreno,iris,nouveau,r300,r600,llvmpipe,softpipe,svga,v3d,vc4,virgl,etnaviv,panfrost,lima,zink,radeonsi,tegra,d3d12,crocus"
++    GALLIUM_DRIVERS: "freedreno,iris,nouveau,kmsro,r300,r600,llvmpipe,softpipe,svga,v3d,vc4,virgl,etnaviv,panfrost,lima,zink,radeonsi,tegra,d3d12,crocus"
+     VULKAN_DRIVERS: intel,amd,broadcom,virtio
+     RUN_MESON_TESTS: "false" # just too slow
+     # Do a host build for mesa-clc (msan complains about uninitialized
+@@ -254,7 +254,7 @@ debian-build-testing:
+       -D gallium-xa=enabled
+       -D gallium-nine=true
+       -D gallium-rusticl=false
+-    GALLIUM_DRIVERS: "i915,iris,nouveau,r300,r600,freedreno,llvmpipe,softpipe,svga,v3d,vc4,virgl,etnaviv,panfrost,lima,zink,d3d12,asahi,crocus"
++    GALLIUM_DRIVERS: "i915,iris,nouveau,kmsro,r300,r600,freedreno,llvmpipe,softpipe,svga,v3d,vc4,virgl,etnaviv,panfrost,lima,zink,d3d12,asahi,crocus"
+     VULKAN_DRIVERS: "intel_hasvk,imagination-experimental,microsoft-experimental,nouveau,swrast"
+     BUILDTYPE: "debugoptimized"
+     EXTRA_OPTION: >
+@@ -323,7 +323,7 @@ debian-release:
+       -D gallium-nine=false
+       -D gallium-rusticl=false
+       -D llvm=enabled
+-    GALLIUM_DRIVERS: "i915,iris,nouveau,r300,freedreno,llvmpipe,softpipe,svga,v3d,vc4,virgl,etnaviv,panfrost,lima,zink,d3d12,asahi,crocus"
++    GALLIUM_DRIVERS: "i915,iris,nouveau,kmsro,r300,freedreno,llvmpipe,softpipe,svga,v3d,vc4,virgl,etnaviv,panfrost,lima,zink,d3d12,asahi,crocus"
+     VULKAN_DRIVERS: "swrast,intel_hasvk,imagination-experimental,microsoft-experimental"
+     EXTRA_OPTION: >
+       -D spirv-to-dxil=true
+@@ -359,7 +359,7 @@ alpine-build-testing:
+       -D egl=enabled
+       -D glvnd=disabled
+       -D platforms=wayland
+-    GALLIUM_DRIVERS: "crocus,etnaviv,freedreno,iris,lima,nouveau,panfrost,r300,r600,radeonsi,svga,llvmpipe,softpipe,tegra,v3d,vc4,virgl,zink"
++    GALLIUM_DRIVERS: "crocus,etnaviv,freedreno,iris,kmsro,lima,nouveau,panfrost,r300,r600,radeonsi,svga,llvmpipe,softpipe,tegra,v3d,vc4,virgl,zink"
+     GALLIUM_ST: >
+       -D gallium-extra-hud=true
+       -D gallium-vdpau=disabled
+@@ -409,7 +409,7 @@ fedora-release:
+       -D intel-rt=enabled
+       -D imagination-srv=true
+       -D teflon=true
+-    GALLIUM_DRIVERS: "crocus,etnaviv,freedreno,i915,iris,lima,nouveau,panfrost,r300,r600,radeonsi,svga,llvmpipe,softpipe,tegra,v3d,vc4,virgl,zink"
++    GALLIUM_DRIVERS: "crocus,etnaviv,freedreno,i915,iris,kmsro,lima,nouveau,panfrost,r300,r600,radeonsi,svga,llvmpipe,softpipe,tegra,v3d,vc4,virgl,zink"
+     GALLIUM_ST: >
+       -D gallium-extra-hud=true
+       -D gallium-vdpau=enabled
+@@ -484,14 +484,14 @@ debian-android:
+     S3_ARTIFACT_NAME: mesa-x86_64-android-${BUILDTYPE}
+   script:
+     - export CROSS=aarch64-linux-android
+-    - export GALLIUM_DRIVERS=etnaviv,freedreno,lima,panfrost,vc4,v3d
++    - export GALLIUM_DRIVERS=etnaviv,freedreno,kmsro,lima,panfrost,vc4,v3d
+     - export VULKAN_DRIVERS=freedreno,broadcom,virtio
+     - *meson-build
+     # x86_64 build:
+     # Can't do AMD drivers because they require LLVM, which is currently
+     # problematic in our Android builds.
+     - export CROSS=x86_64-linux-android
+-    - export GALLIUM_DRIVERS=iris,virgl,zink,softpipe,llvmpipe,swrast
++    - export GALLIUM_DRIVERS=iris,kmsro,virgl,zink,softpipe,llvmpipe,swrast
+     - export VULKAN_DRIVERS=intel,virtio,swrast
+     - .gitlab-ci/create-llvm-meson-wrap-file.sh
+     - *meson-build
+@@ -522,7 +522,7 @@ debian-android:
+     - debian/arm64_build
+   variables:
+     VULKAN_DRIVERS: "asahi,broadcom,freedreno"
+-    GALLIUM_DRIVERS: "etnaviv,freedreno,lima,nouveau,panfrost,llvmpipe,softpipe,tegra,v3d,vc4,zink"
++    GALLIUM_DRIVERS: "etnaviv,freedreno,kmsro,lima,nouveau,panfrost,llvmpipe,softpipe,tegra,v3d,vc4,zink"
+     BUILDTYPE: "debugoptimized"
+   tags:
+     - aarch64
+@@ -538,7 +538,7 @@ debian-arm32:
+       -D glvnd=disabled
+     # remove asahi & llvmpipe from the .meson-arm list because here we have llvm=disabled
+     VULKAN_DRIVERS: "broadcom,freedreno"
+-    GALLIUM_DRIVERS: "etnaviv,freedreno,lima,nouveau,panfrost,softpipe,tegra,v3d,vc4,zink"
++    GALLIUM_DRIVERS: "etnaviv,freedreno,kmsro,lima,nouveau,panfrost,softpipe,tegra,v3d,vc4,zink"
+     EXTRA_OPTION: >
+       -D llvm=disabled
+       -D valgrind=disabled
+@@ -732,7 +732,7 @@ debian-clang:
+       -D microsoft-clc=disabled
+       -D shared-llvm=enabled
+       -D shared-glapi=enabled
+-    GALLIUM_DRIVERS: "iris,nouveau,r300,r600,freedreno,llvmpipe,softpipe,svga,v3d,vc4,virgl,etnaviv,panfrost,lima,zink,radeonsi,tegra,d3d12,crocus,i915,asahi"
++    GALLIUM_DRIVERS: "iris,nouveau,kmsro,r300,r600,freedreno,llvmpipe,softpipe,svga,v3d,vc4,virgl,etnaviv,panfrost,lima,zink,radeonsi,tegra,d3d12,crocus,i915,asahi"
+     VULKAN_DRIVERS: intel,amd,freedreno,broadcom,virtio,swrast,panfrost,imagination-experimental,microsoft-experimental,nouveau
+     EXTRA_OPTION:
+       -D spirv-to-dxil=true
+diff --git a/meson_options.txt b/meson_options.txt
+index 84e0f20dcfd..31baea6000a 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -79,7 +79,7 @@ option(
+   type : 'array',
+   value : ['auto'],
+   choices : [
+-    'auto', 'radeonsi', 'r300', 'r600', 'nouveau', 'freedreno',
++    'auto', 'kmsro', 'radeonsi', 'r300', 'r600', 'nouveau', 'freedreno',
+     'swrast', 'v3d', 'vc4', 'etnaviv', 'tegra', 'i915', 'svga', 'virgl',
+     'panfrost', 'iris', 'lima', 'zink', 'd3d12', 'asahi', 'crocus', 'all',
+     'softpipe', 'llvmpipe',
+-- 
+2.34.1
+

--- a/SPECS/mesa/0007-pipe_kmsro-fix-linking-issue.patch
+++ b/SPECS/mesa/0007-pipe_kmsro-fix-linking-issue.patch
@@ -1,0 +1,30 @@
+From e114c539c3d104cb6dbfab3481f9307b02ac51b4 Mon Sep 17 00:00:00 2001
+From: "Mazlan, Hazwan Arif" <hazwan.arif.mazlan@intel.com>
+Date: Thu, 3 Oct 2024 11:19:20 +0800
+Subject: [PATCH 07/11] pipe_kmsro: fix linking issue
+
+Link iris library while compiling shared library 'pipe_kmsro.so' to fix error:
+| kmsro_drm_winsys.c:(.text.kmsro_drm_screen_create+0x15b):
+| undefined reference to `iris_screen_create_renderonly'
+
+Signed-off-by: Mazlan, Hazwan Arif <hazwan.arif.mazlan@intel.com>
+---
+ src/gallium/targets/pipe-loader/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/gallium/targets/pipe-loader/meson.build b/src/gallium/targets/pipe-loader/meson.build
+index 368f3c1146a..c7d2fe0bf07 100644
+--- a/src/gallium/targets/pipe-loader/meson.build
++++ b/src/gallium/targets/pipe-loader/meson.build
+@@ -18,7 +18,7 @@ pipe_loader_install_dir = join_paths(get_option('libdir'), 'gallium-pipe')
+ 
+ _kmsro_targets = [
+    driver_kmsro, driver_v3d, driver_vc4, driver_freedreno, driver_etnaviv,
+-   driver_panfrost, driver_lima, driver_asahi,
++   driver_panfrost, driver_lima, driver_asahi, driver_iris,
+ ]
+ 
+ if with_gallium_v3d
+-- 
+2.34.1
+

--- a/SPECS/mesa/0008-iris-Added-BMG-PO-Device-ID.patch
+++ b/SPECS/mesa/0008-iris-Added-BMG-PO-Device-ID.patch
@@ -1,0 +1,27 @@
+From 4734741d33701b6603ec1f1fcf54173556fdf2fe Mon Sep 17 00:00:00 2001
+From: "Mazlan, Hazwan Arif" <hazwan.arif.mazlan@intel.com>
+Date: Mon, 25 Nov 2024 14:31:29 +0800
+Subject: [PATCH 08/11] iris: Added BMG PO Device ID
+
+Signed-off-by: Mazlan, Hazwan Arif <hazwan.arif.mazlan@intel.com>
+---
+ include/pci_ids/iris_pci_ids.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/pci_ids/iris_pci_ids.h b/include/pci_ids/iris_pci_ids.h
+index c81740c9722..cd1b5753852 100644
+--- a/include/pci_ids/iris_pci_ids.h
++++ b/include/pci_ids/iris_pci_ids.h
+@@ -277,7 +277,9 @@ CHIPSET(0xe202, bmg, "BMG G21", "Intel(R) Graphics")
+ CHIPSET(0xe20b, bmg, "BMG G21", "Intel(R) Graphics")
+ CHIPSET(0xe20c, bmg, "BMG G21", "Intel(R) Graphics")
+ CHIPSET(0xe20d, bmg, "BMG G21", "Intel(R) Graphics")
++CHIPSET(0xe211, bmg, "BMG G21", "Intel(R) Arc(tm) Pro B60 Graphics")
+ CHIPSET(0xe212, bmg, "BMG G21", "Intel(R) Graphics")
++CHIPSET(0xe216, bmg, "BMG NEX2", "Intel(R) Graphics")
+ 
+ CHIPSET(0xb080, ptl, "PTL", "Intel(R) Graphics", FORCE_PROBE)
+ CHIPSET(0xb081, ptl, "PTL", "Intel(R) Graphics", FORCE_PROBE)
+-- 
+2.34.1
+

--- a/SPECS/mesa/0009-kmsro-Add-xekmd-support.patch
+++ b/SPECS/mesa/0009-kmsro-Add-xekmd-support.patch
@@ -1,0 +1,43 @@
+From 28c774cb71e867e7ecb9dac6353367309fb6673d Mon Sep 17 00:00:00 2001
+From: "Mazlan, Hazwan Arif" <hazwan.arif.mazlan@intel.com>
+Date: Wed, 11 Dec 2024 14:13:50 +0800
+Subject: [PATCH 09/11] kmsro: Add xekmd support
+
+Signed-off-by: Chew, Tong Liang <tong.liang.chew@intel.com>
+Signed-off-by: Mazlan, Hazwan Arif <hazwan.arif.mazlan@intel.com>
+---
+ src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c | 1 +
+ src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c     | 5 +++++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c b/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
+index 9df6c0ce31b..2cd1809da71 100644
+--- a/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
++++ b/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
+@@ -334,6 +334,7 @@ pipe_loader_get_compatible_render_capable_device_fd(int kms_only_fd)
+ #endif
+ #if defined GALLIUM_IRIS
+       "i915",
++      "xe",
+ #endif
+    };
+ 
+diff --git a/src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c b/src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c
+index 46916e86722..618b53fe480 100644
+--- a/src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c
++++ b/src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c
+@@ -126,6 +126,11 @@ struct pipe_screen *kmsro_drm_screen_create(int kms_fd,
+ #if defined(GALLIUM_IRIS)
+       ro->create_for_resource = renderonly_create_kms_dumb_buffer_for_resource,
+       screen = iris_screen_create_renderonly(ro->gpu_fd, ro, config);
++#endif
++   } else if (strcmp(render_dev_name, "xe") == 0) {
++#if defined(GALLIUM_IRIS)
++      ro->create_for_resource = renderonly_create_kms_dumb_buffer_for_resource,
++      screen = iris_screen_create_renderonly(ro->gpu_fd, ro, config);
+ #endif
+    }
+ 
+-- 
+2.34.1
+

--- a/SPECS/mesa/0010-intel-dev-Drop-FORCE_PROBE-from-PTL-devices.patch
+++ b/SPECS/mesa/0010-intel-dev-Drop-FORCE_PROBE-from-PTL-devices.patch
@@ -1,0 +1,37 @@
+From 607517d21318cd343301454318d246d41423304c Mon Sep 17 00:00:00 2001
+From: "Kooran Paul, Princy" <princy.kooran.paul@intel.com>
+Date: Wed, 19 Mar 2025 17:03:05 +0800
+Subject: [PATCH 10/11] intel/dev: Drop FORCE_PROBE from PTL devices
+
+Signed-off-by: Mazlan, Hazwan Arif <hazwan.arif.mazlan@intel.com>
+---
+ include/pci_ids/iris_pci_ids.h | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/include/pci_ids/iris_pci_ids.h b/include/pci_ids/iris_pci_ids.h
+index cd1b5753852..cb5416d5843 100644
+--- a/include/pci_ids/iris_pci_ids.h
++++ b/include/pci_ids/iris_pci_ids.h
+@@ -281,11 +281,11 @@ CHIPSET(0xe211, bmg, "BMG G21", "Intel(R) Arc(tm) Pro B60 Graphics")
+ CHIPSET(0xe212, bmg, "BMG G21", "Intel(R) Graphics")
+ CHIPSET(0xe216, bmg, "BMG NEX2", "Intel(R) Graphics")
+ 
+-CHIPSET(0xb080, ptl, "PTL", "Intel(R) Graphics", FORCE_PROBE)
+-CHIPSET(0xb081, ptl, "PTL", "Intel(R) Graphics", FORCE_PROBE)
+-CHIPSET(0xb082, ptl, "PTL", "Intel(R) Graphics", FORCE_PROBE)
+-CHIPSET(0xb083, ptl, "PTL", "Intel(R) Graphics", FORCE_PROBE)
+-CHIPSET(0xb08f, ptl, "PTL", "Intel(R) Graphics", FORCE_PROBE)
+-CHIPSET(0xb090, ptl, "PTL", "Intel(R) Graphics", FORCE_PROBE)
+-CHIPSET(0xb0a0, ptl, "PTL", "Intel(R) Graphics", FORCE_PROBE)
+-CHIPSET(0xb0b0, ptl, "PTL", "Intel(R) Graphics", FORCE_PROBE)
++CHIPSET(0xb080, ptl, "PTL", "Intel(R) Graphics")
++CHIPSET(0xb081, ptl, "PTL", "Intel(R) Graphics")
++CHIPSET(0xb082, ptl, "PTL", "Intel(R) Graphics")
++CHIPSET(0xb083, ptl, "PTL", "Intel(R) Graphics")
++CHIPSET(0xb08f, ptl, "PTL", "Intel(R) Graphics")
++CHIPSET(0xb090, ptl, "PTL", "Intel(R) Graphics")
++CHIPSET(0xb0a0, ptl, "PTL", "Intel(R) Graphics")
++CHIPSET(0xb0b0, ptl, "PTL", "Intel(R) Graphics")
+-- 
+2.34.1
+

--- a/SPECS/mesa/0011-anv-Print-warning-that-Xe3-is-not-supported-rather-t.patch
+++ b/SPECS/mesa/0011-anv-Print-warning-that-Xe3-is-not-supported-rather-t.patch
@@ -1,0 +1,27 @@
+From 76120aa46d1528e762581729b67f829c5827536f Mon Sep 17 00:00:00 2001
+From: Jordan Justen <jordan.l.justen@intel.com>
+Date: Wed, 4 Oct 2023 13:19:01 -0700
+Subject: [PATCH 11/11] anv: Print warning that Xe3 is not supported rather
+ than failing
+
+Signed-off-by: Jordan Justen <jordan.l.justen@intel.com>
+---
+ src/intel/vulkan/anv_physical_device.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/intel/vulkan/anv_physical_device.c b/src/intel/vulkan/anv_physical_device.c
+index b2eda469415..2fb8872faf3 100644
+--- a/src/intel/vulkan/anv_physical_device.c
++++ b/src/intel/vulkan/anv_physical_device.c
+@@ -2436,6 +2436,8 @@ anv_physical_device_try_create(struct vk_instance *vk_instance,
+       /* If INTEL_FORCE_PROBE was used, then the user has opted-in for
+        * unsupported device support. No need to print a warning message.
+        */
++   } else if (devinfo.ver == 30) {
++      mesa_logw("Vulkan not yet supported on %s", devinfo.name);
+    } else if (devinfo.ver > 20) {
+       result = vk_errorf(instance, VK_ERROR_INCOMPATIBLE_DRIVER,
+                          "Vulkan not yet supported on %s", devinfo.name);
+-- 
+2.34.1
+

--- a/SPECS/mesa/0012-intel-dev-Add-WCL-platform-enum.patch
+++ b/SPECS/mesa/0012-intel-dev-Add-WCL-platform-enum.patch
@@ -1,0 +1,25 @@
+From e3d66dade38be870cd28b7d06d4ffb3da7302650 Mon Sep 17 00:00:00 2001
+From: Jordan Justen <jordan.l.justen@intel.com>
+Date: Mon, 9 Oct 2023 15:50:32 -0700
+Subject: [PATCH 12/15] intel/dev: Add WCL platform enum
+
+Signed-off-by: Jordan Justen <jordan.l.justen@intel.com>
+---
+ src/intel/dev/intel_device_info.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/intel/dev/intel_device_info.py b/src/intel/dev/intel_device_info.py
+index 0591bb0f83e..c2578df1bbc 100644
+--- a/src/intel/dev/intel_device_info.py
++++ b/src/intel/dev/intel_device_info.py
+@@ -135,6 +135,7 @@ Enum("intel_platform",
+       "INTEL_PLATFORM_LNL",
+       "INTEL_PLATFORM_BMG",
+       "INTEL_PLATFORM_PTL",
++      "INTEL_PLATFORM_WCL",
+       ])
+ 
+ Struct("intel_memory_class_instance",
+-- 
+2.34.1
+

--- a/SPECS/mesa/0013-intel-dev-Add-WCL-device-info.patch
+++ b/SPECS/mesa/0013-intel-dev-Add-WCL-device-info.patch
@@ -1,0 +1,30 @@
+From 4fe28582188873b5487a076ebf2e13b3aeb8b6a5 Mon Sep 17 00:00:00 2001
+From: Jordan Justen <jordan.l.justen@intel.com>
+Date: Tue, 10 Oct 2023 00:31:44 -0700
+Subject: [PATCH 13/15] intel/dev: Add WCL device info
+
+Signed-off-by: Jordan Justen <jordan.l.justen@intel.com>
+---
+ src/intel/dev/intel_device_info.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/intel/dev/intel_device_info.c b/src/intel/dev/intel_device_info.c
+index 3cfa68d813d..7c8337abe69 100644
+--- a/src/intel/dev/intel_device_info.c
++++ b/src/intel/dev/intel_device_info.c
+@@ -1273,6 +1273,12 @@ static const struct intel_device_info intel_device_info_ptl = {
+    .has_local_mem = false,
+ };
+ 
++UNUSED static const struct intel_device_info intel_device_info_wcl = {
++   XE3_FEATURES,
++   .platform = INTEL_PLATFORM_WCL,
++   .has_local_mem = false,
++};
++
+ void
+ intel_device_info_topology_reset_masks(struct intel_device_info *devinfo)
+ {
+-- 
+2.34.1
+

--- a/SPECS/mesa/0014-intel-dev-Add-WCL-PCI-IDs.patch
+++ b/SPECS/mesa/0014-intel-dev-Add-WCL-PCI-IDs.patch
@@ -1,0 +1,38 @@
+From 1f940529c9209f9ce3189cb232cbff27c1bcc7f0 Mon Sep 17 00:00:00 2001
+From: Jordan Justen <jordan.l.justen@intel.com>
+Date: Tue, 10 Oct 2023 00:39:45 -0700
+Subject: [PATCH 14/15] intel/dev: Add WCL PCI IDs
+
+Signed-off-by: Jordan Justen <jordan.l.justen@intel.com>
+---
+ include/pci_ids/iris_pci_ids.h    | 3 +++
+ src/intel/dev/intel_device_info.c | 2 +-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/include/pci_ids/iris_pci_ids.h b/include/pci_ids/iris_pci_ids.h
+index cb5416d5843..e988f991d6a 100644
+--- a/include/pci_ids/iris_pci_ids.h
++++ b/include/pci_ids/iris_pci_ids.h
+@@ -289,3 +289,6 @@ CHIPSET(0xb08f, ptl, "PTL", "Intel(R) Graphics")
+ CHIPSET(0xb090, ptl, "PTL", "Intel(R) Graphics")
+ CHIPSET(0xb0a0, ptl, "PTL", "Intel(R) Graphics")
+ CHIPSET(0xb0b0, ptl, "PTL", "Intel(R) Graphics")
++
++CHIPSET(0xfd80, wcl, "WCL", "Intel(R) Graphics")
++CHIPSET(0xfd81, wcl, "WCL", "Intel(R) Graphics")
+diff --git a/src/intel/dev/intel_device_info.c b/src/intel/dev/intel_device_info.c
+index 7c8337abe69..a0e42659a67 100644
+--- a/src/intel/dev/intel_device_info.c
++++ b/src/intel/dev/intel_device_info.c
+@@ -1273,7 +1273,7 @@ static const struct intel_device_info intel_device_info_ptl = {
+    .has_local_mem = false,
+ };
+ 
+-UNUSED static const struct intel_device_info intel_device_info_wcl = {
++static const struct intel_device_info intel_device_info_wcl = {
+    XE3_FEATURES,
+    .platform = INTEL_PLATFORM_WCL,
+    .has_local_mem = false,
+-- 
+2.34.1
+

--- a/SPECS/mesa/0015-add-INTEL_PLATFORM_WCL-and-dev-info.patch
+++ b/SPECS/mesa/0015-add-INTEL_PLATFORM_WCL-and-dev-info.patch
@@ -1,0 +1,57 @@
+From 9d6e97b861bf9589070a7617d9677366a03b4af7 Mon Sep 17 00:00:00 2001
+From: "Wong, Chee Yin" <chee.yin.wong@intel.com>
+Date: Thu, 8 May 2025 22:26:32 +0800
+Subject: [PATCH 15/15] add INTEL_PLATFORM_WCL and dev info
+
+Signed-off-by: Wong, Chee Yin <chee.yin.wong@intel.com>
+---
+ src/intel/dev/gen_wa_helpers.py   | 1 +
+ src/intel/dev/intel_device_info.c | 1 +
+ src/intel/dev/mesa_defs.json      | 7 +++++++
+ 3 files changed, 9 insertions(+)
+
+diff --git a/src/intel/dev/gen_wa_helpers.py b/src/intel/dev/gen_wa_helpers.py
+index 2097be9d300..9f76eb04666 100644
+--- a/src/intel/dev/gen_wa_helpers.py
++++ b/src/intel/dev/gen_wa_helpers.py
+@@ -216,6 +216,7 @@ _PLATFORM_GFXVERS = {"INTEL_PLATFORM_BDW" : 80,
+                      "INTEL_PLATFORM_LNL" : 200,
+                      "INTEL_PLATFORM_BMG" : 200,
+                      "INTEL_PLATFORM_PTL" : 300,
++                     "INTEL_PLATFORM_WCL" : 300,
+                      }
+ 
+ def macro_versions(wa_def):
+diff --git a/src/intel/dev/intel_device_info.c b/src/intel/dev/intel_device_info.c
+index a0e42659a67..43eed6af805 100644
+--- a/src/intel/dev/intel_device_info.c
++++ b/src/intel/dev/intel_device_info.c
+@@ -78,6 +78,7 @@ static const struct {
+    { "lnl", 0x64a0 },
+    { "bmg", 0xe202 },
+    { "ptl", 0xb080 },
++   { "wcl", 0xfd80 },
+ };
+ 
+ /**
+diff --git a/src/intel/dev/mesa_defs.json b/src/intel/dev/mesa_defs.json
+index 8945657f372..0f16fd9d824 100644
+--- a/src/intel/dev/mesa_defs.json
++++ b/src/intel/dev/mesa_defs.json
+@@ -3459,6 +3459,13 @@
+           14023423289
+         ],
+         "steppings": "all"
++      },
++      "INTEL_PLATFORM_WCL": {
++        "ids": [
++          14023423247,
++          14023423289
++        ],
++        "steppings": "all"
+       }
+     }
+   },
+-- 
+2.34.1
+

--- a/SPECS/mesa/mesa.signatures.json
+++ b/SPECS/mesa/mesa.signatures.json
@@ -2,6 +2,6 @@
  "Signatures": {
   "LICENSE.PTR": "1de8e4adc433375c58f2abad074e9d1f7996800f7bc0636554666315d9a30ab8",
   "Mesa-MLAA-License-Clarification-Email.txt": "68e7be52203a4457ea97d9c4744661a07fc3d78edb44a86b43349fb66f09147a",
-  "mesa-24.0.1.tar.xz": "f387192b08c471c545590dd12230a2a343244804b5fe866fec6aea02eab57613"
+  "mesa-25.0.0.tar.xz": "96a53501fd59679654273258c6c6a1055a20e352ee1429f0b123516c7190e5b0"
  }
 }

--- a/SPECS/mesa/mesa.spec
+++ b/SPECS/mesa/mesa.spec
@@ -1,51 +1,55 @@
 %ifnarch s390x
 %global with_hardware 0
+%global with_radeonsi 1
+%global with_vmware 1
 %global with_vulkan_hw 1
 %global with_vdpau 0
 %global with_va 0
 %if !0%{?rhel}
+%global with_r300 1
+%global with_r600 1
 %global with_nine 0
 %global with_nvk 0
-%global with_omx 0
 %global with_opencl 0
 %endif
-%global base_vulkan ,amd
+%global base_vulkan %{?with_vulkan_hw:,amd}%{!?with_vulkan_hw:%{nil}}
+%endif
+
+%ifnarch %{ix86}
+%if !0%{?rhel}
+%global with_teflon 0
+%endif
 %endif
 
 %ifarch %{ix86} x86_64
 %global with_hardware  1
 %global with_crocus 1
 %global with_i915   1
-%if !0%{?rhel}
-%global with_intel_clc 0
-%endif
 %global with_iris   1
 %global with_xa     0
-%global intel_platform_vulkan ,intel,intel_hasvk
+# mesa 25 gallium-iris has clc dep
+%global with_intel_clc 1
+%global intel_platform_vulkan %{?with_vulkan_hw:,intel,intel_hasvk}%{!?with_vulkan_hw:%{nil}}
+%endif
+%ifarch x86_64
+%if !0%{?with_vulkan_hw}
+%global with_intel_vk_rt 1
+%endif
 %endif
 
 %ifarch aarch64 x86_64 %{ix86}
+%global with_kmsro     1
 %if !0%{?rhel}
 %global with_lima      1
 %global with_vc4       1
-%endif
 %global with_etnaviv   1
-%global with_freedreno 1
-%global with_kmsro     1
-%global with_panfrost  1
 %global with_tegra     1
+%endif
+%global with_freedreno 1
+%global with_panfrost  1
 %global with_v3d       1
 %global with_xa        0
-%global extra_platform_vulkan ,broadcom,freedreno,panfrost,imagination-experimental
-%endif
-
-%ifnarch s390x
-%if !0%{?rhel}
-%global with_r300 1
-%global with_r600 1
-%endif
-%global with_radeonsi 1
-%global with_vmware 1
+%global extra_platform_vulkan %{?with_vulkan_hw:,broadcom,freedreno,panfrost,imagination-experimental}%{!?with_vulkan_hw:%{nil}}
 %endif
 
 %if !0%{?rhel}
@@ -60,15 +64,15 @@
 %endif
 
 %if 0%{?with_nvk}
-%global vulkan_drivers swrast%{?base_vulkan}%{?intel_platform_vulkan}%{?extra_platform_vulkan},nouveau-experimental
+%global vulkan_drivers swrast,virtio%{?base_vulkan}%{?intel_platform_vulkan}%{?extra_platform_vulkan}%{?with_nvk:,nouveau}
 %else
-%global vulkan_drivers swrast%{?base_vulkan}%{?intel_platform_vulkan}%{?extra_platform_vulkan}
+%global vulkan_drivers swrast,virtio%{?base_vulkan}%{?intel_platform_vulkan}%{?extra_platform_vulkan}
 %endif
 
 Name:           mesa
 Summary:        Mesa graphics libraries
-Version:        24.0.1
-Release:        4%{?dist}
+Version:        25.0.0
+Release:        1%{?dist}
 License:        BSD
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -83,11 +87,25 @@ Source1:        Mesa-MLAA-License-Clarification-Email.txt
 Source2:        LICENSE.PTR
 
 Patch10:        gnome-shell-glthread-disable.patch
-Patch11:	0001-iris-Add-renderonly-support.patch
-Patch12:	0002-kmsro-Add-iris-renderonly-support.patch
-Patch13:	0003-iris-kmsro-use-ro-device-to-allocate-scanout-for-ren.patch
-Patch14:	0004-meson-version-update.patch
-Patch15:	0005-Revert-Auto-enable-TLSDESC-support.patch
+
+Patch20:        0001-vulkan-wsi-x11-fix-use-of-uninitialised-xfixes-regio.patch
+
+# SRIOV support patches
+Patch30:        0001-iris-Add-renderonly-support.patch
+Patch31:        0002-kmsro-Add-iris-renderonly-support.patch
+Patch32:        0003-iris-kmsro-use-ro-device-to-allocate-scanout-for-ren.patch
+Patch33:        0004-meson-version-update.patch
+Patch34:        0005-Revert-Auto-enable-TLSDESC-support.patch
+Patch35:        0006-Revert-meson-ci-remove-dead-kmsro-option-in-gallium-.patch
+Patch36:        0007-pipe_kmsro-fix-linking-issue.patch
+Patch37:        0008-iris-Added-BMG-PO-Device-ID.patch
+Patch38:        0009-kmsro-Add-xekmd-support.patch
+Patch39:        0010-intel-dev-Drop-FORCE_PROBE-from-PTL-devices.patch
+Patch40:        0011-anv-Print-warning-that-Xe3-is-not-supported-rather-t.patch
+Patch41:        0012-intel-dev-Add-WCL-platform-enum.patch
+Patch42:        0013-intel-dev-Add-WCL-device-info.patch
+Patch43:        0014-intel-dev-Add-WCL-PCI-IDs.patch
+Patch44:        0015-add-INTEL_PLATFORM_WCL-and-dev-info.patch
 
 BuildRequires:  meson >= 1.3.0
 BuildRequires:  gcc
@@ -99,7 +117,7 @@ BuildRequires:  kernel-headers
 # We only check for the minimum version of pkgconfig(libdrm) needed so that the
 # SRPMs for each arch still have the same build dependencies. See:
 # https://bugzilla.redhat.com/show_bug.cgi?id=1859515
-BuildRequires:  pkgconfig(libdrm) >= 2.4.97
+BuildRequires:  pkgconfig(libdrm) >= 2.4.122
 %if 0%{?with_libunwind}
 BuildRequires:  pkgconfig(libunwind)
 %endif
@@ -108,7 +126,7 @@ BuildRequires:  pkgconfig(zlib) >= 1.2.3
 BuildRequires:  pkgconfig(libzstd)
 BuildRequires:  pkgconfig(libselinux)
 BuildRequires:  pkgconfig(wayland-scanner)
-BuildRequires:  pkgconfig(wayland-protocols) >= 1.8
+BuildRequires:  pkgconfig(wayland-protocols) >= 1.34
 BuildRequires:  pkgconfig(wayland-client) >= 1.11
 BuildRequires:  pkgconfig(wayland-server) >= 1.11
 BuildRequires:  pkgconfig(wayland-egl-backend) >= 3
@@ -141,21 +159,30 @@ BuildRequires:  pkgconfig(vdpau) >= 1.1
 %if 0%{?with_va}
 BuildRequires:  pkgconfig(libva) >= 0.38.0
 %endif
-%if 0%{?with_omx}
-BuildRequires:  pkgconfig(libomxil-bellagio)
-%endif
 BuildRequires:  pkgconfig(libelf)
 BuildRequires:  pkgconfig(libglvnd) >= 1.3.2
 BuildRequires:  llvm-devel >= 7.0.0
-%if 0%{?with_opencl} || 0%{?with_nvk}
+%if 0%{?with_teflon}
+BuildRequires:  flatbuffers-devel
+BuildRequires:  flatbuffers-compiler
+BuildRequires:  xtensor-devel
+%endif
+%if 0%{?with_opencl} || 0%{?with_nvk} || 0%{?with_intel_clc}
 BuildRequires:  clang-devel
-BuildRequires:  bindgen
-BuildRequires:  rust < 1.85.0
 BuildRequires:  pkgconfig(libclc)
-BuildRequires:  pkgconfig(SPIRV-Tools)
-BuildRequires:  pkgconfig(LLVMSPIRVLib)
+#BuildRequires:  pkgconfig(SPIRV-Tools)
+#BuildRequires:  pkgconfig(LLVMSPIRVLib)
+BuildRequires:  spirv-llvm-translator-devel
+BuildRequires:  spirv-tools-devel
+Requires:       spirv-llvm-translator
+%endif
+%if 0%{?with_opencl} || 0%{?with_nvk}
+BuildRequires:  bindgen
+BuildRequires:  rust
 %endif
 %if 0%{?with_nvk}
+BuildRequires:  cbindgen
+BuildRequires:  (crate(paste) >= 1.0.14 with crate(paste) < 2)
 BuildRequires:  (crate(proc-macro2) >= 1.0.56 with crate(proc-macro2) < 2)
 BuildRequires:  (crate(quote) >= 1.0.25 with crate(quote) < 2)
 BuildRequires:  (crate(syn/clone-impls) >= 2.0.15 with crate(syn/clone-impls) < 3)
@@ -169,6 +196,8 @@ BuildRequires:  python3-mako
 %if 0%{?with_intel_clc}
 BuildRequires:  python3-ply
 %endif
+BuildRequires:  python3-pycparser
+BuildRequires:  python3-yaml
 BuildRequires:  vulkan-headers
 BuildRequires:  glslang
 %if 0%{?with_vulkan_hw}
@@ -181,15 +210,15 @@ BuildRequires:  pkgconfig(vulkan)
 %package filesystem
 Summary:        Mesa driver filesystem
 Provides:       mesa-dri-filesystem = %{version}-%{release}
+Obsoletes:      mesa-omx-drivers < %{version}-%{release}
 
 %description filesystem
 %{summary}.
 
 %package libGL
 Summary:        Mesa libGL runtime libraries
-Requires:       %{name}-libglapi%{?_isa} = %{version}-%{release}
 Requires:       libglvnd-glx%{?_isa} >= 1.3.2
-Recommends:     %{name}-dri-drivers%{?_isa} = %{version}-%{release}
+Requires:       %{name}-dri-drivers%{?_isa} = %{version}-%{release}
 
 %description libGL
 %{summary}.
@@ -209,8 +238,7 @@ Recommends:     gl-manpages
 Summary:        Mesa libEGL runtime libraries
 Requires:       libglvnd-egl%{?_isa} >= 1.3.2
 Requires:       %{name}-libgbm%{?_isa} = %{version}-%{release}
-Requires:       %{name}-libglapi%{?_isa} = %{version}-%{release}
-Recommends:     %{name}-dri-drivers%{?_isa} = %{version}-%{release}
+Recommends:       %{name}-dri-drivers%{?_isa} = %{version}-%{release}
 
 %description libEGL
 %{summary}.
@@ -229,22 +257,13 @@ Provides:       libEGL-devel%{?_isa}
 %package dri-drivers
 Summary:        Mesa-based DRI drivers
 Requires:       %{name}-filesystem%{?_isa} = %{version}-%{release}
-Requires:       %{name}-libglapi%{?_isa} = %{version}-%{release}
 %if 0%{?with_va}
 Recommends:     %{name}-va-drivers%{?_isa}
 %endif
+Obsoletes:      %{name}-libglapi < 25.0.0~rc2-1
 
 %description dri-drivers
 %{summary}.
-
-%if 0%{?with_omx}
-%package omx-drivers
-Summary:        Mesa-based OMX drivers
-Requires:       %{name}-filesystem%{?_isa} = %{version}-%{release}
-
-%description omx-drivers
-%{summary}.
-%endif
 
 %if 0%{?with_va}
 %package        va-drivers
@@ -267,7 +286,6 @@ Requires:       %{name}-filesystem%{?_isa} = %{version}-%{release}
 
 %package libOSMesa
 Summary:        Mesa offscreen rendering libraries
-Requires:       %{name}-libglapi%{?_isa} = %{version}-%{release}
 Provides:       libOSMesa
 Provides:       libOSMesa%{?_isa}
 
@@ -286,6 +304,10 @@ Summary:        Mesa gbm runtime library
 Provides:       libgbm
 Provides:       libgbm%{?_isa}
 Recommends:     %{name}-dri-drivers%{?_isa} = %{version}-%{release}
+# If mesa-dri-drivers are installed, they must match in version. This is here to prevent using
+# older mesa-dri-drivers together with a newer mesa-libgbm and its dependants.
+# See https://bugzilla.redhat.com/show_bug.cgi?id=2193135 .
+Requires:       %{name}-dri-drivers%{?_isa} = %{version}-%{release}
 
 %description libgbm
 %{summary}.
@@ -318,14 +340,6 @@ Provides:       libxatracker-devel%{?_isa}
 %{summary}.
 %endif
 
-%package libglapi
-Summary:        Mesa shared glapi
-Provides:       libglapi
-Provides:       libglapi%{?_isa}
-
-%description libglapi
-%{summary}.
-
 %if 0%{?with_opencl}
 %package libOpenCL
 Summary:        Mesa OpenCL runtime library
@@ -342,6 +356,14 @@ Summary:        Mesa OpenCL development package
 Requires:       %{name}-libOpenCL%{?_isa} = %{version}-%{release}
 
 %description libOpenCL-devel
+%{summary}.
+%endif
+
+%if 0%{?with_teflon}
+%package libTeflon
+Summary:        Mesa TensorFlow Lite delegate
+
+%description libTeflon
 %{summary}.
 %endif
 
@@ -363,6 +385,7 @@ Requires:       %{name}-libd3d%{?_isa} = %{version}-%{release}
 %package vulkan-drivers
 Summary:        Mesa Vulkan drivers
 Requires:       vulkan%{_isa}
+Requires:       %{name}-filesystem%{?_isa} = %{version}-%{release}
 Obsoletes:      mesa-vulkan-devel < %{version}-%{release}
 
 %description vulkan-drivers
@@ -387,6 +410,7 @@ export MESON_PACKAGE_CACHE_DIR="%{cargo_registry}/"
 %rewrite_wrap_file quote
 %rewrite_wrap_file syn
 %rewrite_wrap_file unicode-ident
+%rewrite_wrap_file paste
 %endif
 
 # We've gotten a report that enabling LTO for mesa breaks some games. See
@@ -396,7 +420,6 @@ export MESON_PACKAGE_CACHE_DIR="%{cargo_registry}/"
 
 %meson \
   -Dplatforms=x11,wayland \
-  -Ddri3=enabled \
   -Dosmesa=true \
 %if 0%{?with_hardware}
   -Dgallium-drivers=swrast,virgl,nouveau%{?with_r300:,r300}%{?with_crocus:,crocus}%{?with_i915:,i915}%{?with_iris:,iris}%{?with_vmware:,svga}%{?with_radeonsi:,radeonsi}%{?with_r600:,r600}%{?with_freedreno:,freedreno}%{?with_etnaviv:,etnaviv}%{?with_tegra:,tegra}%{?with_vc4:,vc4}%{?with_v3d:,v3d}%{?with_kmsro:,kmsro}%{?with_lima:,lima}%{?with_panfrost:,panfrost} \
@@ -407,11 +430,6 @@ export MESON_PACKAGE_CACHE_DIR="%{cargo_registry}/"
   -Dgallium-vdpau=enabled \
 %else
   -Dgallium-vdpau=disabled \
-%endif
-%if 0%{?with_omx}
-  -Dgallium-omx=bellagio \
-%else
-  -Dgallium-omx=disabled \
 %endif
 %if 0%{?with_va}
   -Dgallium-va=enabled \
@@ -427,6 +445,11 @@ export MESON_PACKAGE_CACHE_DIR="%{cargo_registry}/"
   -Dgallium-nine=true \
 %else
   -Dgallium-nine=false \
+%endif
+%if 0%{?with_teflon}
+  -Dteflon=true \
+%else
+  -Dteflon=false \
 %endif
 %if 0%{?with_opencl}
   -Dgallium-opencl=icd \
@@ -444,11 +467,14 @@ export MESON_PACKAGE_CACHE_DIR="%{cargo_registry}/"
   -Dgbm=enabled \
   -Dglx=dri \
   -Degl=enabled \
-  -Dglvnd=true \
+  -Dglvnd=enabled \
 %if 0%{?with_intel_clc}
   -Dintel-clc=enabled \
+%endif
+%if 0%{?with_intel_vk_rt}
+  -Dintel-rt=enabled \
 %else
-  -Dintel-clc=disabled \
+  -Dintel-rt=disabled \
 %endif
   -Dmicrosoft-clc=disabled \
   -Dllvm=enabled \
@@ -472,7 +498,7 @@ export MESON_PACKAGE_CACHE_DIR="%{cargo_registry}/"
 %endif
   -Dandroid-libbacktrace=disabled \
 %ifarch %{ix86}
-  -Dglx-read-only-text=true
+  -Dglx-read-only-text=true \
 %endif
   %{nil}
 %meson_build
@@ -503,20 +529,16 @@ popd
 %license LICENSE.PTR
 %doc docs/Mesa-MLAA-License-Clarification-Email.txt
 %dir %{_libdir}/dri
-%if 0%{?with_hardware}
-%if 0%{?with_vdpau}
-%dir %{_libdir}/vdpau
-%endif
-%endif
+%dir %{_datadir}/drirc.d
 
 %files libGL
 %{_libdir}/libGLX_mesa.so.0*
 %{_libdir}/libGLX_system.so.0*
 %files libGL-devel
+%dir %{_includedir}/GL
 %dir %{_includedir}/GL/internal
 %{_includedir}/GL/internal/dri_interface.h
 %{_libdir}/pkgconfig/dri.pc
-%{_libdir}/libglapi.so
 
 %files libEGL
 %{_datadir}/glvnd/egl_vendor.d/50_mesa.json
@@ -525,12 +547,6 @@ popd
 %dir %{_includedir}/EGL
 %{_includedir}/EGL/eglext_angle.h
 %{_includedir}/EGL/eglmesaext.h
-
-%post libglapi -p /sbin/ldconfig
-%postun libglapi -p /sbin/ldconfig
-%files libglapi
-%{_libdir}/libglapi.so.0
-%{_libdir}/libglapi.so.0.*
 
 %post libOSMesa -p /sbin/ldconfig
 %postun libOSMesa -p /sbin/ldconfig
@@ -571,6 +587,11 @@ popd
 %endif
 %endif
 
+%if 0%{?with_teflon}
+%files libTeflon
+%{_libdir}/libteflon.so
+%endif
+
 %if 0%{?with_opencl}
 %post libOpenCL -p /sbin/ldconfig
 %postun libOpenCL -p /sbin/ldconfig
@@ -579,6 +600,7 @@ popd
 %{_libdir}/libRusticlOpenCL.so.*
 %{_sysconfdir}/OpenCL/vendors/mesa.icd
 %{_sysconfdir}/OpenCL/vendors/rusticl.icd
+
 %files libOpenCL-devel
 %{_libdir}/libMesaOpenCL.so
 %{_libdir}/libRusticlOpenCL.so
@@ -596,9 +618,11 @@ popd
 %endif
 
 %files dri-drivers
-%dir %{_datadir}/drirc.d
 %{_datadir}/drirc.d/00-mesa-defaults.conf
+%{_libdir}/libgallium-*.so
+%{_libdir}/gbm/dri_gbm.so
 %{_libdir}/dri/kms_swrast_dri.so
+%{_libdir}/dri/libdril_dri.so
 %{_libdir}/dri/swrast_dri.so
 %{_libdir}/dri/virtio_gpu_dri.so
 
@@ -650,10 +674,16 @@ popd
 %endif
 %if 0%{?with_panfrost}
 %{_libdir}/dri/panfrost_dri.so
+%{_libdir}/dri/panthor_dri.so
 %endif
 %{_libdir}/dri/nouveau_dri.so
 %if 0%{?with_vmware}
 %{_libdir}/dri/vmwgfx_dri.so
+%endif
+%endif
+%if 0%{?with_opencl}
+%dir %{_libdir}/gallium-pipe
+%{_libdir}/gallium-pipe/*.so
 %endif
 %if 0%{?with_kmsro}
 %{_libdir}/dri/armada-drm_dri.so
@@ -673,21 +703,20 @@ popd
 %{_libdir}/dri/pl111_dri.so
 %{_libdir}/dri/repaper_dri.so
 %{_libdir}/dri/rockchip_dri.so
+%{_libdir}/dri/rzg2l-du_dri.so
+%{_libdir}/dri/ssd130x_dri.so
 %{_libdir}/dri/st7586_dri.so
 %{_libdir}/dri/st7735r_dri.so
 %{_libdir}/dri/sti_dri.so
 %{_libdir}/dri/sun4i-drm_dri.so
 %{_libdir}/dri/udl_dri.so
+%{_libdir}/dri/vkms_dri.so
+%{_libdir}/dri/zynqmp-dpsub_dri.so
 %endif
+%if ! 0%{?emt}
+%if 0%{?with_vulkan_hw}
+%{_libdir}/dri/zink_dri.so
 %endif
-%if 0%{?with_opencl}
-%dir %{_libdir}/gallium-pipe
-%{_libdir}/gallium-pipe/*.so
-%endif
-
-%if 0%{?with_omx}
-%files omx-drivers
-%{_libdir}/bellagio/libomx_mesa.so
 %endif
 
 %if 0%{?with_va}
@@ -704,6 +733,7 @@ popd
 
 %if 0%{?with_vdpau}
 %files vdpau-drivers
+%dir %{_libdir}/vdpau
 %{_libdir}/vdpau/libvdpau_nouveau.so.1*
 %if 0%{?with_r600}
 %{_libdir}/vdpau/libvdpau_r600.so.1*
@@ -717,6 +747,8 @@ popd
 %files vulkan-drivers
 %{_libdir}/libvulkan_lvp.so
 %{_datadir}/vulkan/icd.d/lvp_icd.*.json
+%{_libdir}/libvulkan_virtio.so
+%{_datadir}/vulkan/icd.d/virtio_icd.*.json
 %{_libdir}/libVkLayer_MESA_device_select.so
 %{_datadir}/vulkan/implicit_layer.d/VkLayer_MESA_device_select.json
 %if 0%{?with_vulkan_hw}
@@ -747,6 +779,11 @@ popd
 %endif
 
 %changelog
+* Fri Sep 19 2025 Swee Yee Fonn <swee.yee.fonn@intel.com> - 25.0.0-1
+- Upgrade to Mesa 25 based on Fedora 41. License verified.
+- Upgrade to version 25.0.0 required for SRIOV
+- Take SRIOV MESA debian patch ref taken: 60593bad64d4b2f10de3a457253eeb8ec4cb76a5
+
 * Fri May 30 2025 Ranjan Dutta <ranjan.dutta@intel.com> - 24.0.1-4
 - merge from Azure Linux 3.0.20250521-3.0
 - Pin rust version

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -13531,8 +13531,8 @@
         "type": "other",
         "other": {
           "name": "mesa",
-          "version": "24.0.1",
-          "downloadUrl": "https://archive.mesa3d.org/mesa-24.0.1.tar.xz"
+          "version": "25.0.0",
+          "downloadUrl": "https://archive.mesa3d.org/mesa-25.0.0.tar.xz"
         }
       }
     },


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Update mesa to 25.0.0 and include SRIOV patches for Intel desktop virtualization support.
Note: needs https://github.com/open-edge-platform/edge-microvisor-toolkit/pull/441 for build dependency 

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Built mesa with dependencies wayland-proctocol/wayland into edge-image-desktop-virtualization-dev image and boot. 
Verify edge-image-desktop-virtualization-dev image is booting and installed version is mesa 25 on RPL-S.
guest@EdgeMicrovisorToolkit [ ~ ]$ sudo -E tdnf list installed  mesa*
Loaded plugin: tdnfrepogpgcheck
mesa-dri-drivers.x86_64                                                                      25.0.0-1.emt3                                                @System
mesa-filesystem.x86_64                                                                       25.0.0-1.emt3                                                @System
mesa-libEGL.x86_64                                                                           25.0.0-1.emt3                                                @System
mesa-libGL.x86_64                                                                            25.0.0-1.emt3                                                @System
mesa-libgbm.x86_64                                                                           25.0.0-1.emt3                                                @System

Verified able to start IDV on EMT host and able to run glxgears with "MESA_LOADER_DRIVER_OVERRIDE=pl111" in EMT guest with IDV on EMT host. Also able to run glxgears in EMT host.

<img width="1906" height="1076" alt="Screenshot 2025-09-19 143443" src="https://github.com/user-attachments/assets/9898e011-a826-4b17-a0aa-10ca7108bec6" />


