### PR TITLE
[DOCS] hide toctrees in markdown files

### DIFF
--- a/docs/developer-guide/emt-get-started.md
+++ b/docs/developer-guide/emt-get-started.md
@@ -28,7 +28,7 @@ applications.
 
 ## Host Guest VMs under Edge Microvisor Toolkit
 
-[Deploying Oth<!--hide_directiveer OS as Guest Virtual Machines under EMT Host](./get-started/deployment/emt-vm-host.md)
+[Deploying Other OS as Guest Virtual Machines under EMT Host](./get-started/deployment/emt-vm-host.md)
 
 <!--hide_directive
 :::{toctree}

--- a/docs/developer-guide/emt-get-started.md
+++ b/docs/developer-guide/emt-get-started.md
@@ -28,11 +28,12 @@ applications.
 
 ## Host Guest VMs under Edge Microvisor Toolkit
 
-[Deploying Other OS as Guest Virtual Machines under EMT Host](./get-started/deployment/emt-vm-host.md)
+[Deploying Oth<!--hide_directiveer OS as Guest Virtual Machines under EMT Host](./get-started/deployment/emt-vm-host.md)
 
-
+<!--hide_directive
 :::{toctree}
 ./get-started/emt-building-howto.md
 ./get-started/emt-build-and-deploy.md
 ./get-started/emt-installation-howto.md
 :::
+hide_directive-->

--- a/docs/developer-guide/emt-security-considerations.md
+++ b/docs/developer-guide/emt-security-considerations.md
@@ -15,7 +15,9 @@ Intel is committed to rapidly addressing security vulnerabilities affecting our 
 ## Reporting a Vulnerability
 Please report any security vulnerabilities in this project [utilizing the guidelines here](https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html).
 
+<!--hide_directive
 :::{toctree}
 ./security-considerations/emt-sb-howto.md
 ./security-considerations/emt-security-overview.md
 :::
+hide_directive-->

--- a/docs/developer-guide/get-started/emt-installation-howto.md
+++ b/docs/developer-guide/get-started/emt-installation-howto.md
@@ -12,8 +12,10 @@ describes in detail how to quickly install and try out Edge Microvisor Toolkit o
 - Learn how to [Enable Secure Boot for Edge Microvisor Toolkit](../security-considerations/emt-sb-howto.md).
 - Learn how to customize and manually [build microvisor images](./emt-building-howto.md).
 
+<!--hide_directive
 :::{toctree}
 ./deployment/emt-bare-metal.md
 ./deployment/emt-vm-guest.md
 ./deployment/emt-vm-host.md
 :::
+hide_directive-->


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [X] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description 

Toctree RST directives hidden, no longer appear on Github docs preview

#### How Has This Been Tested? <!-- REQUIRED -->
Local build and github fork preview
