### PR TITLE
Fix umount var error during system reboot

### DIFF
--- a/SPECS/systemd/stop-journal-flush.service
+++ b/SPECS/systemd/stop-journal-flush.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Stop systemd-journal-flush before shutdown
+DefaultDependencies=no
+Before=shutdown.target reboot.target 
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/system/stop-journal-flush.sh
+StandardOutput=journal
+StandardError=journal
+RemainAfterExit=yes
+
+[Install]
+WantedBy=shutdown.target reboot.target

--- a/SPECS/systemd/stop-journal-flush.sh
+++ b/SPECS/systemd/stop-journal-flush.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+if [ -x /usr/bin/systemctl ]; then
+    /usr/bin/systemctl stop systemd-journal-flush.service >/dev/null 2>&1 || :
+fi

--- a/SPECS/systemd/systemd.signatures.json
+++ b/SPECS/systemd/systemd.signatures.json
@@ -23,6 +23,8 @@
   "sysusers.generate-pre.sh": "6d503de2db2374125cb5c3b6034636514b58a38dcff193550768c3c49c6d7419",
   "sysusers.prov": "0dcc4b699030c11eccedb850d4d2c097ebdc725766e17db56f942ee445b93cf6",
   "triggers.systemd": "ee7398bec872cc3717d396d201c0a9d4239b883d5f43cb609ab83b229119ceb6",
-  "yum-protect-systemd.conf": "5a5aa0a6cdfb432f890351ebd1f62d05f9a04d5aa58f57d0758686afaa8d3617"
+  "yum-protect-systemd.conf": "5a5aa0a6cdfb432f890351ebd1f62d05f9a04d5aa58f57d0758686afaa8d3617",
+  "stop-journal-flush.service": "005b20eff19b00155dbe0419bc0273fc879d4f87a4f2a296b163c18a73bc4b86",
+  "stop-journal-flush.sh": "8c0c1293bb3fa5a324689deb97e651e4c3e19bd621eecea2179eacd007f8d210"
  }
 }

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -50,7 +50,7 @@ Version:        255
 # determine the build information from local checkout
 Version:        %(tools/meson-vcs-tag.sh . error | sed -r 's/-([0-9])/.^\1/; s/-g/_g/')
 %endif
-Release:        29%{?dist}
+Release:        30%{?dist}
 
 # FIXME - hardcode to 'stable' for now as that's what we have in our blobstore
 %global stable 1
@@ -110,6 +110,8 @@ Source28:       99-yama-ptrace.conf
 Source29:       99-net-core-bpf-jit-harden.conf
 Source30:       99-kernel.conf
 Source31:       99-tcp-timestamps.conf
+Source32:       stop-journal-flush.service
+Source33:       stop-journal-flush.sh
 
 %if 0
 GIT_DIR=../../src/systemd/.git git format-patch-ab --no-signature -M -N v235..v235-stable
@@ -871,6 +873,7 @@ install -Dm0644 -t %{buildroot}%{_pkgdocdir}/ %{SOURCE28}
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1378974
 install -Dm0644 -t %{buildroot}%{system_unit_dir}/systemd-udev-trigger.service.d/ %{SOURCE10}
+install -Dm0777 -t %{buildroot}%{_unitdir} %{SOURCE33}
 
 # systemd-oomd default configuration
 install -Dm0644 -t %{buildroot}%{_prefix}/lib/systemd/oomd.conf.d/ %{SOURCE14}
@@ -885,6 +888,7 @@ install -Dm0644 -t %{buildroot}%{_prefix}/lib/sysctl.d/ %{SOURCE17}
 
 # Install TCP timestamp setting
 install -Dm0644 -t %{buildroot}%{_prefix}/lib/sysctl.d/ %{SOURCE31}
+install -Dpm 644 %{SOURCE32} %{buildroot}%{_unitdir}/stop-journal-flush.service
 
 %if 0%{?emt}
 install -Dm0644 -t %{buildroot}%{_prefix}/lib/sysctl.d/ %{SOURCE18}
@@ -975,6 +979,8 @@ systemd-tmpfiles --create &>/dev/null || :
 # https://fedoraproject.org/wiki/Changes/Systemd_presets_for_user_units.
 systemctl preset-all &>/dev/null || :
 systemctl --global preset-all &>/dev/null || :
+systemctl enable stop-journal-flush.service
+systemctl daemon-reload
 
 %postun
 if [ $1 -eq 1 ]; then
@@ -982,7 +988,7 @@ if [ $1 -eq 1 ]; then
    systemd-tmpfiles --create &>/dev/null || :
 fi
 
-%systemd_postun_with_restart systemd-timedated.service systemd-hostnamed.service systemd-journald.service systemd-localed.service systemd-userdbd.service
+%systemd_postun_with_restart systemd-timedated.service systemd-hostnamed.service systemd-journald.service systemd-localed.service systemd-userdbd.service stop-journal-flush.service
 
 # FIXME: systemd-logind.service is excluded (https://github.com/systemd/systemd/pull/17558)
 
@@ -1050,6 +1056,9 @@ grep -q -E '^KEYMAP="?fi-latin[19]"?' /etc/vconsole.conf 2>/dev/null &&
 
 %preun udev
 %systemd_preun %udev_services
+
+%preun
+%systemd_preun stop-journal-flush.service
 
 %postun udev
 # Restart some services.
@@ -1237,6 +1246,11 @@ rm -f %{name}.lang
 # %autochangelog. So we need to continue manually maintaining the
 # changelog here.
 %changelog
+
+* Thu Oct 16 2025 Basavaraj unniche <basavarajx.unniche@intel.com> - 255-30
+- Add new service to stop systemd-journal-flush.service which is
+- umount issues during reboot
+
 * Fri May 30 2025 Ranjan Dutta <ranjan.dutta@intel.com> - 255-29
 - merge from Azure Linux 3.0.20250521-3.0
 - Bumping 'Release' tag to match the 'signed' version of the spec.


### PR DESCRIPTION
  - Added new service to stop systemd-journal-flush.service
  - during system reboot.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
During system reboot, umount /var is having conflict and error is shown on console.

<!-- Fixes # (issue) -->


#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
Created image and tested.
