### PR TITLE
xdp-tools: add patch to fix libbpf version prefix issue

### DIFF
--- a/SPECS/xdp-tools/0001-remove-prefix-version-9999.patch
+++ b/SPECS/xdp-tools/0001-remove-prefix-version-9999.patch
@@ -1,0 +1,30 @@
+From a9f15ee30463c1a1c5ffdbd97370c60e178036e4 Mon Sep 17 00:00:00 2001
+From: Lee Chee Yang <chee.yang.lee@intel.com>
+Date: Thu, 9 Nov 2023 13:24:59 +0800
+Subject: [PATCH] remove prefix version 9999
+
+provided libbpf9999 where we added 9999 version prefix, this prefix can cause compilation error.
+
+/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: error: 'strncpy' output truncated copying 9 bytes from a string of length 10 [-Werror=stringop-truncation]
+
+Signed-off-by: Lee Chee Yang <chee.yang.lee@intel.com>
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 70fdfdf..8b6a254 100755
+--- a/configure
++++ b/configure
+@@ -236,7 +236,7 @@ check_libbpf()
+ 
+         LIBBPF_CFLAGS=$(${PKG_CONFIG} libbpf --cflags)
+         LIBBPF_LDLIBS=$(${PKG_CONFIG} libbpf --libs)
+-        LIBBPF_VERSION=$(${PKG_CONFIG} libbpf --modversion)
++        LIBBPF_VERSION=$(${PKG_CONFIG} libbpf --modversion | sed 's/^9999.//')
+ 
+         cat >$TMPDIR/libbpftest.c <<EOF
+ #include <bpf/libbpf.h>
+-- 
+2.34.1
+

--- a/SPECS/xdp-tools/xdp-tools.spec
+++ b/SPECS/xdp-tools/xdp-tools.spec
@@ -3,7 +3,7 @@ Vendor:           Intel Corporation
 Distribution:     Edge Microvisor Toolkit
 Name:             xdp-tools
 Version:          1.4.2
-Release:          3%{?dist}
+Release:          4%{?dist}
 Summary:          Utilities and example programs for use with XDP
 License:          GPL-2.0-only
 URL:              https://github.com/xdp-project/%{name}
@@ -37,6 +37,7 @@ Requires:         libxdp = %{version}-%{release}
 
 # TSN patches
 Patch0:           0001-if_xdp.h-add-txtime-field-in-xdp_desc-struct.patch
+Patch1:           0001-remove-prefix-version-9999.patch
 
 # find-debuginfo produces empty debugsourcefiles.list
 # disable the debug package to avoid rpmbuild error'ing out because of this
@@ -146,6 +147,9 @@ make install V=1
 %{_libdir}/pkgconfig/libxdp.pc
 
 %changelog
+* Fri Oct 24 2025 polmoorx shiva kumar <polmoorx.shiva.kumar@intel.com> 1.4.2-4
+- Add patch support to remove the '9999.' version prefix from libbpf in configure
+
 * Wed Jun 04 2025 Aaron Chan <aaron.chun.yew.chan@intel.com> 1.4.2-3
 - Add TSN patches/support
 


### PR DESCRIPTION
xdp-tools: add patch to fix libbpf version prefix issue

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Added a patch to remove the '9999.' version prefix from libbpf in configure, which causes string truncation errors during build. Updated the spec file to include this patch.
<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->
NO
#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Manually tested
