### PR TITLE
Resolve qemu host-libusb assert issue

### DIFF
--- a/SPECS/qemu/0058-hw-usb-host-libusb-Do-not-assert-when-detects-invali.patch
+++ b/SPECS/qemu/0058-hw-usb-host-libusb-Do-not-assert-when-detects-invali.patch
@@ -1,0 +1,63 @@
+From b5e4fa8886c09c676a28279369d9ea334bdb77bb Mon Sep 17 00:00:00 2001
+From: Liang1 Yang <liang1.yang@intel.com>
+Date: Thu, 30 Oct 2025 20:07:41 +0800
+Subject: [PATCH 1/1] hw/usb/host-libusb: Do not assert when detects invalid
+ alt
+
+Log warning and skip the interface instead of asserting in qemu
+host-libusb when there is invalid altsetting index during fast
+USB device hotplug/unplug.
+This is to prevent guest vm from crashing which is caused by
+QEMU task abort.
+
+Signed-off-by: Liang1 Yang <liang1.yang@intel.com>
+---
+ hw/usb/host-libusb.c | 25 ++++++++++++++++++++++++-
+ 1 file changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/hw/usb/host-libusb.c b/hw/usb/host-libusb.c
+index 691bc881fb..3a08caafa5 100644
+--- a/hw/usb/host-libusb.c
++++ b/hw/usb/host-libusb.c
+@@ -885,6 +885,15 @@ static void usb_host_ep_update(USBHostDevice *s)
+     trace_usb_host_parse_config(s->bus_num, s->addr,
+                                 conf->bConfigurationValue, true);
+ 
++    /* Log and skip if configuration is NULL or has no interfaces */
++    if (!conf || conf->bNumInterfaces == 0) {
++        warn_report("usb-host: ignoring invalid configuration "
++            "for device %s (bus=%03d, addr=%03d)",
++            udev->product_desc ? udev->product_desc : "unknown",
++            s->bus_num, s->addr);
++        return;
++    }
++
+     for (i = 0; i < conf->bNumInterfaces; i++) {
+         /*
+          * The udev->altsetting array indexes alternate settings
+@@ -896,7 +905,21 @@ static void usb_host_ep_update(USBHostDevice *s)
+         alt = udev->altsetting[intf->bInterfaceNumber];
+ 
+         if (alt != 0) {
+-            assert(alt < conf->interface[i].num_altsetting);
++            if (alt >= conf->interface[i].num_altsetting) {
++                /*
++                 * Recommend fix: sometimes libusb reports a temporary
++                 * invalid altsetting index during fast hotplug/unplug.
++                 * Instead of aborting, log a warning and skip the interface.
++                 */
++                warn_report("usb-host: ignoring invalid altsetting=%d (max=%d) "
++                    "for interface=%d on %s (bus=%03d, addr=%03d)",
++                    alt,
++                    conf->interface[i].num_altsetting ? conf->interface[i].num_altsetting - 1 : -1,
++                    i,
++                    udev->product_desc ? udev->product_desc : "unknown",
++                    s->bus_num, s->addr);
++                continue;
++            }
+             intf = &conf->interface[i].altsetting[alt];
+         }
+ 
+-- 
+2.35.3
+

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -446,7 +446,7 @@ Obsoletes: sgabios-bin <= 1:0.20180715git-10.fc38
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 9.1.0
-Release: 4%{?dist}
+Release: 5%{?dist}
 License: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND FSFAP AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND MIT AND LicenseRef-Fedora-Public-Domain AND CC-BY-3.0
 URL: http://www.qemu.org/
 
@@ -539,6 +539,7 @@ Patch57: 0054-hw-display-virtio-gpu-Redundant-call-of-dpy_gfx_repl.patch
 Patch58: 0055-hw-display-virtio-gpu-Manual-res-flush-to-redraw-sav.patch
 Patch59: 0056-hw-display-virtio-gpu-Properly-free-current_cursor.patch
 Patch60: 0057-ui-gtk-Re-grabbing-PTR-KBD-individually.patch
+Patch61: 0058-hw-usb-host-libusb-Do-not-assert-when-detects-invali.patch
 
 BuildRequires: gnupg2
 BuildRequires: meson >= %{meson_version}
@@ -3537,6 +3538,10 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 
 
 %changelog
+* Thu Oct 30 2025 Liang Yang <liang1.yang@intel.com> - 9.1.0-5
+- Added 1 patch from Intel Distribution Qemu Commit 3fbf5c5
+- Fix assert in qemu host-libusb when altsetting invalid
+
 * Fri Oct 3 2025 Lee Chee Yang <chee.yang.lee@intel.com> - 9.1.0-4
 - Bump to rebuild with updated glibc
 - python-tomli -> python3-tomli


### PR DESCRIPTION
Log warning and skip the interface instead of asserting in qemu host-libusb 
when there is invalid altsetting index during fast USB device hotplug/unplug.
This is to prevent guest vm from crashing which is caused by QEMU task abort.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Prevent qemu from asserting in qemu host-libusb when there is invalid altsetting index during fast USB device hotplug/unplug.
<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
- Built and tested local build of DV raw image
- Flash and bootup ok
- Launch guest vm with new version of qemu ok
- Tested USB device (eg. USB keyboard, USB mouse, USB Audio headset) passthrough ok
- Further testing of IDV ISO with USB device passthrough and hotplug (unplug/replug) use cases tested ok by UCC/BB team