### PR TITLE
Add helm to rt/non-rt images

### DIFF
--- a/toolkit/imageconfigs/edge-image-dev.json
+++ b/toolkit/imageconfigs/edge-image-dev.json
@@ -76,7 +76,7 @@
                 "packagelists/intel-wireless.json",
                 "packagelists/os-ab-update.json",
                 "packagelists/vpro-amt-packages.json",
-		"packagelists/helm.json",
+                "packagelists/helm.json",
                 "packagelists/docker.json"
             ],
             "AdditionalFiles": {

--- a/toolkit/imageconfigs/edge-image-dev.json
+++ b/toolkit/imageconfigs/edge-image-dev.json
@@ -76,6 +76,7 @@
                 "packagelists/intel-wireless.json",
                 "packagelists/os-ab-update.json",
                 "packagelists/vpro-amt-packages.json",
+		"packagelists/helm.json",
                 "packagelists/docker.json"
             ],
             "AdditionalFiles": {

--- a/toolkit/imageconfigs/edge-image-rt-dev.json
+++ b/toolkit/imageconfigs/edge-image-rt-dev.json
@@ -76,7 +76,7 @@
                 "packagelists/intel-wireless.json",
                 "packagelists/os-ab-update.json",
                 "packagelists/vpro-amt-packages.json",
-		"packagelists/helm.json",
+                "packagelists/helm.json",
                 "packagelists/docker.json"
             ],
             "AdditionalFiles": {

--- a/toolkit/imageconfigs/edge-image-rt-dev.json
+++ b/toolkit/imageconfigs/edge-image-rt-dev.json
@@ -76,6 +76,7 @@
                 "packagelists/intel-wireless.json",
                 "packagelists/os-ab-update.json",
                 "packagelists/vpro-amt-packages.json",
+		"packagelists/helm.json",
                 "packagelists/docker.json"
             ],
             "AdditionalFiles": {

--- a/toolkit/imageconfigs/edge-image-rt.json
+++ b/toolkit/imageconfigs/edge-image-rt.json
@@ -76,6 +76,7 @@
                 "packagelists/intel-wireless.json",
                 "packagelists/os-ab-update.json",
                 "packagelists/vpro-amt-packages.json",
+                "packagelists/helm.json",
                 "packagelists/docker.json"
             ],
             "AdditionalFiles": {

--- a/toolkit/imageconfigs/edge-image.json
+++ b/toolkit/imageconfigs/edge-image.json
@@ -76,6 +76,7 @@
                 "packagelists/intel-wireless.json",
                 "packagelists/os-ab-update.json",
                 "packagelists/vpro-amt-packages.json",
+                "packagelists/helm.json",
                 "packagelists/docker.json"
             ],
             "AdditionalFiles": {


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Include helm in rt & non-rt images as well similar to dv. This helps user make helm deployments of applications in immutable image.
Tested with oxm deployment of - https://files-rs.edgeorchestration.intel.com/files-edge-orch/repository/microvisor/dev/non_rt/edge-non-prod-3.0.20251107.0558.raw.gz

<img width="1852" height="144" alt="image" src="https://github.com/user-attachments/assets/cceec0f4-9c95-4211-b8ec-7f508689a6b5" />

<img width="872" height="160" alt="Screenshot 2025-11-07 133907" src="https://github.com/user-attachments/assets/0775ec7a-7726-4f94-b90d-ede8d044e01e" />



<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
