### PR TITLE
SPEC/nvidia: upgrade nvidia data center driver to 580.105.08

### DIFF
--- a/SPECS/nvidia-data-center-driver/nvidia-data-center-driver.signatures.json
+++ b/SPECS/nvidia-data-center-driver/nvidia-data-center-driver.signatures.json
@@ -1,0 +1,5 @@
+{
+ "Signatures": {
+  "NVIDIA-Linux-x86_64-580.105.08.run": "d9c6e8188672f3eb74dd04cfa69dd58479fa1d0162c8c28c8d17625763293475"
+ }
+}

--- a/SPECS/nvidia-data-center-driver/nvidia-data-center-driver.spec
+++ b/SPECS/nvidia-data-center-driver/nvidia-data-center-driver.spec
@@ -1,0 +1,76 @@
+%global debug_package %{nil}
+
+# Currently this spec could be built nvidia driver for one kernel-devel
+# package - It is ok because there is only one kernel in uki image. If there is
+# requirement that there are two or more kernels in system, related kernel
+# versions need to be pre-defined in this spec so nvidia driver could be built
+# with these kernels.
+%global kernel_ver `ls /lib/modules/`
+
+Summary:        nvidia gpu driver kernel module for data center devices
+Name:           nvidia-data-center-driver
+Version:        580.105.08
+Release:        1%{?dist}
+License:        Public Domain
+Source0:        https://us.download.nvidia.com/tesla/%{version}/NVIDIA-Linux-x86_64-%{version}.run
+Vendor:         Intel Corporation
+Distribution:   Edge Microvisor Toolkit
+
+BuildRequires:  kernel-devel
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  binutils
+BuildRequires:  make
+
+%description
+This kernel driver package contains Nvidia data center GPU driver.
+
+%prep
+cp -p %{SOURCE0} .
+chmod 755 %{SOURCE0}
+rm -rf NVIDIA-Linux-x86_64-%{version}
+sh ./NVIDIA-Linux-x86_64-%{version}.run -x
+
+%build
+export KERNEL_UNAME=%{kernel_ver}
+unset LDFLAGS
+cd NVIDIA-Linux-x86_64-%{version}/kernel
+make %{?_smp_mflags} modules
+
+%install
+export KERNEL_UNAME=%{kernel_ver}
+cd NVIDIA-Linux-x86_64-%{version}/kernel
+make INSTALL_MOD_PATH=%{buildroot} modules_install
+
+%files
+%defattr(-,root,root)
+%license NVIDIA-Linux-x86_64-%{version}/LICENSE
+/lib/modules/
+
+%post
+/sbin/depmod -a
+
+%changelog
+* Mon Nov 10 2025 Junxiao Chang <junxiao.chang@intel.com> - 580.105.08-1
+- Updrade Nvidia data center driver to 580.105.08
+
+* Fri Oct 10 2025 Zhang Baoli <baoli.zhang@intel.com> - 570.133.20-7
+- Fix ISO mouse detection and cmdline params in non-rt kernel
+
+* Tue Sep 30 2025 Zhang Baoli <baoli.zhang@intel.com> - 570.133.20-6
+- Bump release to rebuild
+
+* Tue Sep 09 2025 Ren Jiaojiao <jiaojiaox.ren@intel.com> - 570.133.20-5
+- Bump release to rebuild
+
+* Thu Jul 24 2025 Ren Jiaojiao <jiaojiaox.ren@intel.com> - 570.133.20-4
+- Bump release to rebuild
+
+* Thu Jul 10 2025 Ren Jiaojiao <jiaojiaox.ren@intel.com> - 570.133.20-3
+- Bump release to rebuild
+
+* Fri Jul 04 2025 Anuj Mittal <anuj.mittal@intel.com> - 570.133.20-2
+- Bump release to rebuild
+
+* Mon May 26 2025 Junxiao Chang <junxiao.chang@intel.com> 570.133.20-1
+- Original version for Edge Microvisor Toolkit. License verified.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -14921,6 +14921,16 @@
       "component": {
         "type": "other",
         "other": {
+          "name": "nvidia-data-center-driver",
+          "version": "580.105.08",
+          "downloadUrl": "https://us.download.nvidia.com/tesla/580.105.08/NVIDIA-Linux-x86_64-580.105.08.run"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
           "name": "nvidia-modprobe",
           "version": "550.54.14",
           "downloadUrl": "https://github.com/NVIDIA/nvidia-modprobe/archive/550.54.14.tar.gz"


### PR DESCRIPTION
This change is to fix nvidia driver build issue with 6.17 kernel.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
This change is to upgrade Nvidia data center driver to 580.105.08, to fix build issue with 6.17 kernel.
<!-- Fixes # (issue) -->
https://jira.devtools.intel.com/browse/ITEP-81201

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
With this change, nvidia driver could be built with 6.17 kernel, kernel driver loading is good with 4060ti.