### PR TITLE
Add non-root user to the docker group for non-root Docker access

### DIFF
--- a/toolkit/imageconfigs/additionalconfigs/add-docker-group.sh
+++ b/toolkit/imageconfigs/additionalconfigs/add-docker-group.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+if id "guest" &>/dev/null; then
+    usermod -aG docker guest
+fi

--- a/toolkit/imageconfigs/edge-image-desktop-virtualization-dev.json
+++ b/toolkit/imageconfigs/edge-image-desktop-virtualization-dev.json
@@ -97,6 +97,9 @@
                 },
                 {
                         "Path": "additionalconfigs/add-sudoer.sh"
+                },
+                {
+                        "Path": "additionalconfigs/add-docker-group.sh"
                 }
             ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/edge-image-dev.json
+++ b/toolkit/imageconfigs/edge-image-dev.json
@@ -91,6 +91,9 @@
                 },
                 {
                         "Path": "additionalconfigs/add-sudoer.sh"
+                },
+                {
+                        "Path": "additionalconfigs/add-docker-group.sh"
                 }
             ],
             "KernelOptions": {

--- a/toolkit/imageconfigs/edge-image-rt-dev.json
+++ b/toolkit/imageconfigs/edge-image-rt-dev.json
@@ -91,6 +91,9 @@
                 },
                 {
                         "Path": "additionalconfigs/add-sudoer.sh"
+                },
+                {
+                        "Path": "additionalconfigs/add-docker-group.sh"
                 }
             ],
             "KernelOptions": {


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
The non-root user couldn’t run Docker commands without sudo because it was not part of the 'docker' group. Added a new script to automatically detect the default non-root user and add it to the docker group, This allows non-root to use Docker without sudo while keeping existing sudo behavior intact.

This allows guest to use Docker without sudo while keeping existing sudo behavior intact.
<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->
NO
#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Manually tested
