### PR TITLE
edge-release further fixes

### DIFF
--- a/SPECS/edge-release/edge-release.spec
+++ b/SPECS/edge-release/edge-release.spec
@@ -1,4 +1,4 @@
-
+%define emt_ver 3
 %define dist_version 25.06
 %define build_number_no_dist_no_time %(echo %{distro_release_version} | cut -d. -f 3)
 
@@ -55,7 +55,7 @@ cat <<-"EOF" > %{buildroot}%{_libdir}/os-release
 NAME="%{distribution}"
 VERSION="%{distro_full_version}"
 ID="Edge Microvisor Toolkit"
-VERSION_ID="%{version}"
+VERSION_ID="3.0"
 PRETTY_NAME="%{distribution} %{distro_full_version}"
 ANSI_COLOR="1;34"
 HOME_URL="%{url}"
@@ -80,9 +80,9 @@ cat <<-"EOF" > %{buildroot}%{_rpmmacrodir}/macros.dist
 # dist macros.
 
 %%__bootstrap         ~bootstrap
-%%emt                 %{dist_version}
-%%emt%{dist_version}  1
-%%dist                .emt%{dist_version}%%{?with_bootstrap:%%{__bootstrap}}
+%%emt                 %{emt_ver}
+%%emt%{emt_ver}  1
+%%dist                .emt%{emt_ver}%%{?with_bootstrap:%%{__bootstrap}}
 %%dist_vendor         %{vendor}
 %%dist_name           %{distribution}
 %%dist_home_url       %{url}


### PR DESCRIPTION
set "emt" value to 3.0 as the macros affect a lot of other rpms. hardcode VERSION_ID to 3.0 as it is referred by other packages like kata container.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
package like kata-container contain some code that refer to VERSION_ID and it is hardcoded to look for 3.0 or 2.0.
workaround by hardcode VERSION_ID to original series of  "3.0" 

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
#1281 