### PR TITLE
Upgrade xdp-tools to 1.5.8 to fix PTL issue

### DIFF
--- a/SPECS/xdp-tools/xdp-tools.signatures.json
+++ b/SPECS/xdp-tools/xdp-tools.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "xdp-tools-1.4.2.tar.gz": "2c916b5a9d26e64e8003e9b7d0e168c74520bff7a30f0345c80ae15eafc4ed0f"
+  "xdp-tools-1.5.8.tar.gz": "9f6eb9f2275c2431f59a80a99549b27c66832a751dd03c5993c6bc3f5c724b25"
  }
 }

--- a/SPECS/xdp-tools/xdp-tools.spec
+++ b/SPECS/xdp-tools/xdp-tools.spec
@@ -1,9 +1,9 @@
-%global _soversion 1.4.0
+%global _soversion 1.5.0
 Vendor:           Intel Corporation
 Distribution:     Edge Microvisor Toolkit
 Name:             xdp-tools
-Version:          1.4.2
-Release:          3%{?dist}
+Version:          1.5.8
+Release:          1%{?dist}
 Summary:          Utilities and example programs for use with XDP
 License:          GPL-2.0-only
 URL:              https://github.com/xdp-project/%{name}
@@ -13,6 +13,7 @@ BuildRequires:    libbpf-devel
 BuildRequires:    elfutils-libelf-devel
 BuildRequires:    zlib-devel
 BuildRequires:    libpcap-devel
+BuildRequires:    libcap-ng-devel
 BuildRequires:    clang >= 10.0.0
 BuildRequires:    llvm >= 10.0.0
 BuildRequires:    make
@@ -120,6 +121,7 @@ make install V=1
 %{_sbindir}/xdpdump
 %ifnarch i686
 %{_sbindir}/xdp-bench
+%{_sbindir}/xdp-forward
 %{_sbindir}/xdp-monitor
 %{_sbindir}/xdp-trafficgen
 %endif
@@ -146,6 +148,9 @@ make install V=1
 %{_libdir}/pkgconfig/libxdp.pc
 
 %changelog
+* Wed Dec 10 2025 kintalix Jayanth <jayanthx.kintali@intel.com> 1.5.8-1
+- Version upgrade of xdp-tools from 1.4.2 to 1.5.8
+
 * Wed Jun 04 2025 Aaron Chan <aaron.chun.yew.chan@intel.com> 1.4.2-3
 - Add TSN patches/support
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -31011,8 +31011,8 @@
         "type": "other",
         "other": {
           "name": "xdp-tools",
-          "version": "1.4.2",
-          "downloadUrl": "https://github.com/xdp-project/xdp-tools/releases/download/v1.4.2/xdp-tools-1.4.2.tar.gz"
+          "version": "1.5.8",
+          "downloadUrl": "https://github.com/xdp-project/xdp-tools/releases/download/v1.5.8/xdp-tools-1.5.8.tar.gz"
         }
       }
     },


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [X] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
ITEP-82786: xdp-tools was failing to work properly on the PTL environment due to version incompatibilities and missing dependencies.
To resolve the issue, xdp-tools has been upgraded from 1.4.2 to 1.5.8, and all related files (spec, signatures, cgmanifest) have been updated.
This ensures successful build, installation, and functionality of xdp-tools in PTL.

#### Any Newly Introduced Dependencies
No

#### How Has This Been Tested? <!-- REQUIRED -->
Tested Manually

<img width="1455" height="445" alt="image" src="https://github.com/user-attachments/assets/f464fd47-7017-4a5a-82f8-d5a4911f5679" />
<img width="1512" height="909" alt="image" src="https://github.com/user-attachments/assets/81bfc634-be47-484b-aaf2-78a005816c6b" />

