### PR TITLE
Added support for second package condition/version argument in conver…

### DIFF
--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -670,63 +670,63 @@ func (r *RpmRepoCloner) clonePackage(baseArgs []string) (preBuilt bool, err erro
 }
 
 func convertPackageVersionToTdnfArg(pkgVer *pkgjson.PackageVer) (tdnfArg string) {
-        tdnfArg = pkgVer.Name
+	tdnfArg = pkgVer.Name
 
-        // TDNF does not accept versioning information on implicit provides.
-        if pkgVer.IsImplicitPackage() {
-                if pkgVer.Condition != "" || pkgVer.SCondition != "" {
-                        logger.Log.Warnf("Discarding version constraint for implicit package: %v", pkgVer)
-                }
-                return
-        }
+	// TDNF does not accept versioning information on implicit provides.
+	if pkgVer.IsImplicitPackage() {
+		if pkgVer.Condition != "" || pkgVer.SCondition != "" {
+			logger.Log.Warnf("Discarding version constraint for implicit package: %v", pkgVer)
+		}
+		return
+	}
 
-        // Handle first condition
-        var firstConstraint, secondConstraint string
-        
-        switch pkgVer.Condition {
-        case "":
-        case "=":
-                firstConstraint = fmt.Sprintf("%s-%s", pkgVer.Name, pkgVer.Version)
-                tdnfArg = firstConstraint // For exact matches, use this format
-                return // Don't process second condition for exact matches
-        case "<=", "<":
-                firstConstraint = fmt.Sprintf("%s %s %s", pkgVer.Name, pkgVer.Condition, pkgVer.Version)
-        case ">", ">=":
-                logger.Log.Warnf("Discarding '%s' version constraint for performance: %v", pkgVer.Condition, pkgVer)
-                // Don't set firstConstraint, we're discarding this
-        default:
-                if pkgVer.Condition != "" {
-                        logger.Log.Errorf("Unsupported version constraint: %s", pkgVer.Condition)
-                }
-        }
+	// Handle first condition
+	var firstConstraint, secondConstraint string
 
-        // Handle second condition
-        switch pkgVer.SCondition {
-        case "":
-        case "=":
-                secondConstraint = fmt.Sprintf("%s-%s", pkgVer.Name, pkgVer.SVersion)
-        case "<=", "<":
-                secondConstraint = fmt.Sprintf("%s %s %s", pkgVer.Name, pkgVer.SCondition, pkgVer.SVersion)
-        case ">", ">=":
-                logger.Log.Warnf("Discarding '%s' second version constraint for performance: %v", pkgVer.SCondition, pkgVer)
-                // Don't set secondConstraint, we're discarding this
-        default:
-                if pkgVer.SCondition != "" {
-                        logger.Log.Errorf("Unsupported second version constraint: %s", pkgVer.SCondition)
-                }
-        }
+	switch pkgVer.Condition {
+	case "":
+	case "=":
+		firstConstraint = fmt.Sprintf("%s-%s", pkgVer.Name, pkgVer.Version)
+		tdnfArg = firstConstraint // For exact matches, use this format
+		return // Don't process second condition for exact matches
+	case "<=", "<":
+		firstConstraint = fmt.Sprintf("%s %s %s", pkgVer.Name, pkgVer.Condition, pkgVer.Version)
+	case ">", ">=":
+		logger.Log.Warnf("Discarding '%s' version constraint for performance: %v", pkgVer.Condition, pkgVer)
+		// Don't set firstConstraint, we're discarding this
+	default:
+		if pkgVer.Condition != "" {
+			logger.Log.Errorf("Unsupported version constraint: %s", pkgVer.Condition)
+		}
+	}
 
-        // Combine constraints
-        if firstConstraint != "" && secondConstraint != "" {
-                tdnfArg = fmt.Sprintf("%s %s", firstConstraint, secondConstraint)
-        } else if firstConstraint != "" {
-                tdnfArg = firstConstraint
-        } else if secondConstraint != "" {
-                tdnfArg = secondConstraint
-        }
-        // else tdnfArg remains just the package name
+	// Handle second condition
+	switch pkgVer.SCondition {
+	case "":
+	case "=":
+		secondConstraint = fmt.Sprintf("%s-%s", pkgVer.Name, pkgVer.SVersion)
+	case "<=", "<":
+		secondConstraint = fmt.Sprintf("%s %s %s", pkgVer.Name, pkgVer.SCondition, pkgVer.SVersion)
+	case ">", ">=":
+		logger.Log.Warnf("Discarding '%s' second version constraint for performance: %v", pkgVer.SCondition, pkgVer)
+		// Don't set secondConstraint, we're discarding this
+	default:
+		if pkgVer.SCondition != "" {
+			logger.Log.Errorf("Unsupported second version constraint: %s", pkgVer.SCondition)
+		}
+	}
 
-        return
+	// Combine constraints
+	if firstConstraint != "" && secondConstraint != "" {
+		tdnfArg = fmt.Sprintf("%s %s", firstConstraint, secondConstraint)
+	} else if firstConstraint != "" {
+		tdnfArg = firstConstraint
+	} else if secondConstraint != "" {
+		tdnfArg = secondConstraint
+	}
+	// else tdnfArg remains just the package name
+
+	return
 }
 
 func (r *RpmRepoCloner) GetRepoSnapshotTime() string {

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -683,6 +683,10 @@ func convertPackageVersionToTdnfArg(pkgVer *pkgjson.PackageVer) (tdnfArg string)
 	// Handle first condition
 	var firstConstraint, secondConstraint string
 
+
+	// To avoid significant overhead we only download the latest version of a package
+	// for ">" and ">=" constraints (ie remove constraints).
+
 	switch pkgVer.Condition {
 	case "":
 	case "=":

--- a/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
+++ b/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go
@@ -670,31 +670,63 @@ func (r *RpmRepoCloner) clonePackage(baseArgs []string) (preBuilt bool, err erro
 }
 
 func convertPackageVersionToTdnfArg(pkgVer *pkgjson.PackageVer) (tdnfArg string) {
-	tdnfArg = pkgVer.Name
+        tdnfArg = pkgVer.Name
 
-	// TDNF does not accept versioning information on implicit provides.
-	if pkgVer.IsImplicitPackage() {
-		if pkgVer.Condition != "" {
-			logger.Log.Warnf("Discarding version constraint for implicit package: %v", pkgVer)
-		}
-		return
-	}
+        // TDNF does not accept versioning information on implicit provides.
+        if pkgVer.IsImplicitPackage() {
+                if pkgVer.Condition != "" || pkgVer.SCondition != "" {
+                        logger.Log.Warnf("Discarding version constraint for implicit package: %v", pkgVer)
+                }
+                return
+        }
 
-	// To avoid significant overhead we only download the latest version of a package
-	// for ">" and ">=" constraints (ie remove constraints).
-	switch pkgVer.Condition {
-	case "":
-	case "=":
-		tdnfArg = fmt.Sprintf("%s-%s", pkgVer.Name, pkgVer.Version)
-	case "<=", "<":
-		tdnfArg = fmt.Sprintf("%s %s %s", pkgVer.Name, pkgVer.Condition, pkgVer.Version)
-	case ">", ">=":
-		logger.Log.Warnf("Discarding '%s' version constraint for: %v", pkgVer.Condition, pkgVer)
-	default:
-		logger.Log.Errorf("Unsupported version constraint: %s", pkgVer.Condition)
-	}
+        // Handle first condition
+        var firstConstraint, secondConstraint string
+        
+        switch pkgVer.Condition {
+        case "":
+        case "=":
+                firstConstraint = fmt.Sprintf("%s-%s", pkgVer.Name, pkgVer.Version)
+                tdnfArg = firstConstraint // For exact matches, use this format
+                return // Don't process second condition for exact matches
+        case "<=", "<":
+                firstConstraint = fmt.Sprintf("%s %s %s", pkgVer.Name, pkgVer.Condition, pkgVer.Version)
+        case ">", ">=":
+                logger.Log.Warnf("Discarding '%s' version constraint for performance: %v", pkgVer.Condition, pkgVer)
+                // Don't set firstConstraint, we're discarding this
+        default:
+                if pkgVer.Condition != "" {
+                        logger.Log.Errorf("Unsupported version constraint: %s", pkgVer.Condition)
+                }
+        }
 
-	return
+        // Handle second condition
+        switch pkgVer.SCondition {
+        case "":
+        case "=":
+                secondConstraint = fmt.Sprintf("%s-%s", pkgVer.Name, pkgVer.SVersion)
+        case "<=", "<":
+                secondConstraint = fmt.Sprintf("%s %s %s", pkgVer.Name, pkgVer.SCondition, pkgVer.SVersion)
+        case ">", ">=":
+                logger.Log.Warnf("Discarding '%s' second version constraint for performance: %v", pkgVer.SCondition, pkgVer)
+                // Don't set secondConstraint, we're discarding this
+        default:
+                if pkgVer.SCondition != "" {
+                        logger.Log.Errorf("Unsupported second version constraint: %s", pkgVer.SCondition)
+                }
+        }
+
+        // Combine constraints
+        if firstConstraint != "" && secondConstraint != "" {
+                tdnfArg = fmt.Sprintf("%s %s", firstConstraint, secondConstraint)
+        } else if firstConstraint != "" {
+                tdnfArg = firstConstraint
+        } else if secondConstraint != "" {
+                tdnfArg = secondConstraint
+        }
+        // else tdnfArg remains just the package name
+
+        return
 }
 
 func (r *RpmRepoCloner) GetRepoSnapshotTime() string {


### PR DESCRIPTION
…tPackageVersionToTdnfArg function.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->
It was discovered that building a package with its SPEC file having two version arguments for the same depended package will result in the toolkit trying to install the latest version of the depended package. 

### Example (SPEC file & build command):
BuildRequires:  golang < 1.25
BuildRequires:  golang >= 1.24.9

```
sudo make -j8 build-packages \
                      REBUILD_TOOLS=y CONFIG_FILE= \
                      SRPM_PACK_LIST="${specList}" CONCURRENT_PACKAGE_BUILDS=8 \
                      VALIDATE_TOOLCHAIN_GPG=n \
```
This SPEC file will result in the toolkit choosing to use the latest golang package (v1.25.1) 

Investigation leads to the discovery of this specific function: `convertPackageVersionToTdnfArg` in this file: edge-microvisor-toolkit/toolkit/tools/internal/packagerepo/repocloner/rpmrepocloner/rpmrepocloner.go forgetting to process the second version argument `pkgVer.SCondition`. 

The original code removes the `>=` argument to avoid overheads. On top of that, it ignores the possibility of the package having a second argument, in this case, `<`. It was also verified that switching the first and second version argument (switching order) will result in the same outcome. 



#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
The `convertPackageVersionToTdnfArg` function in rpmrepocloner.go was modified to be able to process the second version argument when it's required. The same build command was used and the result now showed that the correct version of golang is used:
<img width="888" height="52" alt="image" src="https://github.com/user-attachments/assets/c85e156a-3cf3-4ff0-84bb-5c444ebc620d" />
