### PR TITLE
upgrade alsa-sof-firmware version - next

### DIFF
--- a/SPECS/alsa-sof-firmware/alsa-sof-firmware.signatures.json
+++ b/SPECS/alsa-sof-firmware/alsa-sof-firmware.signatures.json
@@ -1,5 +1,5 @@
 {
   "Signatures": {
-    "sof-bin-2025.05.tar.gz": "e2f2603b0d38c7cbdb1672901863fbf84b4db4921f405952a236915cb8a86bcc"
+    "sof-bin-2025.12.tar.gz": "2f7aed784d2fa092c750651e949727f2ae4e9e39cca2c6bfed420f618adf2a9e"
   }
 }

--- a/SPECS/alsa-sof-firmware/alsa-sof-firmware.spec
+++ b/SPECS/alsa-sof-firmware/alsa-sof-firmware.spec
@@ -4,7 +4,7 @@
 %global _firmwarepath  /usr/lib/firmware
 %global _xz_opts -9 --check=crc32
 
-%global sof_ver 2025.05
+%global sof_ver 2025.12
 #global sof_ver_pre rc1
 %global sof_ver_rel %{?sof_ver_pre:.%{sof_ver_pre}}
 %global sof_ver_pkg0 %{sof_ver}%{?sof_ver_pre:-%{sof_ver_pre}}
@@ -18,7 +18,7 @@
 Summary:        Firmware and topology files for Sound Open Firmware project
 Name:           alsa-sof-firmware
 Version:        %{sof_ver}
-Release:        3%{?dist}
+Release:        1%{?dist}
 License:        BSD-3-Clause AND Apache-2.0
 Distribution:   Edge Microvisor Toolkit
 Vendor:         Intel Corporation
@@ -163,6 +163,9 @@ if st and st.type == "directory" then
 end
 
 %changelog
+* Mon Jan 12 2026 Basavarajx unniche <basavarajx.unniche@intel.com> - 2025.12-1
+- Update version to 2025.12.
+
 * Tue Aug 26 2025 Rajesh Shanmugam<rajesh1x.shanmugam@intel.com> - 2025.05-3
 - Initial Edge Microvisor Toolkit import from Fedora 43 (license: MIT)
 - License verified.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -185,8 +185,8 @@
         "type": "other",
         "other": {
           "name": "alsa-sof-firmware",
-          "version": "2025.05",
-          "downloadUrl": "https://github.com/thesofproject/sof-bin/releases/download/v2025.05/sof-bin-2025.05.tar.gz"
+          "version": "2025.12",
+          "downloadUrl": "https://github.com/thesofproject/sof-bin/releases/download/v2025.12/sof-bin-2025.12.tar.gz"
         }
       }
     },

--- a/toolkit/imageconfigs/packagelists/developer-packages.json
+++ b/toolkit/imageconfigs/packagelists/developer-packages.json
@@ -20,6 +20,7 @@
         "tar",
         "texinfo",
         "usbutils",
-        "wget"
+        "wget",
+        "alsa-sof-firmware"
     ]
 }


### PR DESCRIPTION
 - Upgrade version to 2025.12 to include firmware
 - file's for ARL and MTL platforms.
 - changes to install alsa-sof-firmware package during ISO installation.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [X] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
ITEP-82176 : Upgrade sof-firmware to latest version which include firmware files for ARL and MTL platforms. As requested, alsa-sof-firmware package needs to be installed as part of tiber ISO installation.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
Generated ISO with changes, installed and verified. Updated test results and engineering build in ITEP.
<img width="417" height="417" alt="image" src="https://github.com/user-attachments/assets/f1b9f372-ae75-4a37-b93a-1931a28a94c6" />
Version Upgrade:
<img width="417" height="91" alt="image" src="https://github.com/user-attachments/assets/3ee0e70a-04d7-4452-b5e0-944cf6cd3c02" />

