### PR TITLE
Added golang version limitation for go-rpm-macros

### DIFF
--- a/SPECS/go-rpm-macros/go-rpm-macros.spec
+++ b/SPECS/go-rpm-macros/go-rpm-macros.spec
@@ -1,8 +1,8 @@
 %global rcluadir %{_rpmconfigdir}/lua/azl
 %global rpmmacrodir %{_rpmconfigdir}/macros.d
 
-Vendor:         Microsoft Corporation
-Distribution:   Azure Linux
+Vendor:         Intel Corporation
+Distribution:   Edge Microvisor Toolkit
 %global forgeurl  https://pagure.io/go-rpm-macros
 Version:   3.6.0
 %forgemeta

--- a/SPECS/go-rpm-macros/go-rpm-macros.spec
+++ b/SPECS/go-rpm-macros/go-rpm-macros.spec
@@ -21,7 +21,7 @@ Version:   3.6.0
 ExclusiveArch: %{golang_arches} %{gccgo_arches}
 
 Name:      go-rpm-macros
-Release:   1%{?dist}
+Release:   2%{?dist}
 Summary:   Build-stage rpm automation for Go packages
 
 License:   GPLv3+
@@ -33,7 +33,7 @@ Requires:  go-srpm-macros = %{version}-%{release}
 Requires:  go-filesystem  = %{version}-%{release}
 
 %ifarch %{golang_arches}
-Requires:  golang
+Requires:  golang < 1.25
 Provides:  compiler(golang)
 Provides:  compiler(go-compiler) = 2
 Obsoletes: go-compilers-golang-compiler < %{version}-%{release}

--- a/SPECS/go-rpm-macros/go-rpm-macros.spec
+++ b/SPECS/go-rpm-macros/go-rpm-macros.spec
@@ -159,6 +159,10 @@ install -m 0644 -vp   rpm/macros.d/macros.go-compilers-gcc \
 %{_spectemplatedir}/*.spec
 
 %changelog
+* Mon Jan 19 2026 Chia Cherng Xi <cherng.xi.chia@intel.com> - 3.6.0-2
+- Restricted golang to use version older than 1.25
+- Bumped release version to 2
+
 * Wed Nov 20 2024 Durga Jagadeesh Palli <v-dpalli@microsoft.com> - 3.6.0-1
 - Update to 3.6.0.
 - License verified


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
caddy.spec delta build failed when bumping its release number, found out the issue arises from caddy spec file that depends on the go-rpm-macros package to be built. 

Go-rpm-macros package requires golang to be built, but in the spec file it doesn't specify the version, so it will fetch the latest golang version available. However, the caddy spec file has limited the golang version to be between >= 1.24.4 and <1.25. This caused two golang versions to be installed here when doing delta build targeted for caddy. The go-rpm-macros has to be rebuilt instead of downloading the rpm from our repository during delta build. 

The same issue can be recreated using SRPM_PACK_LIST="caddy go-rpm-macros" PACKAGE_REBUILD_LIST="caddy go-rpm-macros" flag in a normal build, without the delta build flag.

This is a snipped from the failed log file caddy-2.9.1-14.emt3.src.rpm.log:
<img width="1664" height="142" alt="Screenshot 2026-01-16 114516" src="https://github.com/user-attachments/assets/a0874596-5cac-4d82-b73f-300b51348253" />

Limiting go-rpm-macros golang version solves this issue.
<img width="1193" height="818" alt="image" src="https://github.com/user-attachments/assets/e847b23e-f7bd-4e02-93e7-abcc39cca374" />

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
