### PR TITLE
Removed go-rpm-macros dependency in caddy.spec

### DIFF
--- a/SPECS/caddy/caddy.spec
+++ b/SPECS/caddy/caddy.spec
@@ -3,7 +3,7 @@
 Summary:        Web server with automatic HTTPS
 Name:           caddy
 Version:        2.9.1
-Release:        15%{?dist}
+Release:        16%{?dist}
 Distribution:   Edge Microvisor Toolkit
 Vendor:         Intel Corporation
 # main source code is Apache-2.0
@@ -31,7 +31,6 @@ Patch2:         CVE-2025-22869.patch
 Patch3:         CVE-2024-45339.patch
 Patch4:         CVE-2025-22872.patch
 Patch5:         CVE-2025-58181.patch
-BuildRequires:  go-rpm-macros
 # https://github.com/caddyserver/caddy/commit/2028da4e74cd41f0f7f94222c6599da1a371d4b8
 BuildRequires:  golang >= 1.24.4
 BuildRequires:  golang < 1.25
@@ -454,6 +453,9 @@ fi
 %{_datadir}/fish/vendor_completions.d/caddy.fish
 
 %changelog
+* Thu Jan 22 2026 Cherng Xi Chia <cherng.xi.chia@intel.com> - 2.9.1-16
+- Removed go-rpm-macros dependency
+
 * Fri Jan 09 2026 Basavarajx unniche <basavarajx.unniche@intel.com> - 2.9.1-15
 - Include patch for CVE-2025-58181.
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [v] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [v] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Caddy failed in delta build due to different golang requirement from go-rpm-macros and caddy itself, removed go-rpm-macros dependency in caddy.spec. Caddy spec file can be built without the go-rpm-macros 
<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. --> no

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Did a delta build with the caddy spec changes and managed to build successfully
<img width="1261" height="749" alt="image" src="https://github.com/user-attachments/assets/198d0afa-73ac-4287-930e-61a26573416f" />
