### PR TITLE
Fix QEMU CVEs

### DIFF
--- a/SPECS/qemu/pcie_sriov_CVE-2025-54567_CVE-2025-54566.patch
+++ b/SPECS/qemu/pcie_sriov_CVE-2025-54567_CVE-2025-54566.patch
@@ -1,0 +1,89 @@
+From 8e06d09dc2bb4f10a83ba4f3a8fbab70ced01d81 Mon Sep 17 00:00:00 2001
+From: Dongwon Kim <dongwon.kim@intel.com>
+Date: Wed, 14 Jan 2026 14:49:35 -0800
+Subject: [PATCH] pcie_sriov: Fix configuration and state synchronization
+
+Fix issues in PCIe SR-IOV configuration register handling that caused
+inconsistent internal state due to improper write mask handling.
+
+The problem was identified in pcie_sriov_config_write() which incorrectly
+assumed that its val parameter was already masked, causing it to ignore
+the actual write mask. This led to the VF Enable bit being processed
+even when masked, resulting in incorrect VF registration/unregistration.
+It is identified as CVE-2025-54567.
+
+Root cause analysis revealed that the function relied on incorrect
+special-case assumptions instead of properly reading and consuming
+the actual configuration values. This change introduces a unified
+consume_config() function that reads actual configuration values and
+synchronizes the internal state without special-case assumptions.
+
+This is a partial backport of the upstream QEMU patch. The migration-
+related fix (CVE-2025-54566) is not applicable to this QEMU 9.1.0
+version as it lacks the pcie_sriov_pf_post_load function.
+
+Original patch:
+https://gitlab.com/qemu-project/qemu/-/commit/cad9aa6fbdccd95e56e10cfa57c354a20a333717
+
+Fixes: CVE-2025-54567
+Cc: qemu-stable@nongnu.org
+Reported-by: Corentin BAYET <corentin.bayet@reversetactics.com>
+Signed-off-by: Akihiko Odaki <odaki@rsg.ci.i.u-tokyo.ac.jp>
+Reviewed-by: Michael S. Tsirkin <mst@redhat.com>
+Signed-off-by: Michael S. Tsirkin <mst@redhat.com>
+---
+ hw/pci/pcie_sriov.c | 34 +++++++++++++++++++++++-----------
+ 1 file changed, 23 insertions(+), 11 deletions(-)
+
+diff --git a/hw/pci/pcie_sriov.c b/hw/pci/pcie_sriov.c
+index e9b23221d71..acce9bc1738 100644
+--- a/hw/pci/pcie_sriov.c
++++ b/hw/pci/pcie_sriov.c
+@@ -215,6 +215,28 @@ static void unregister_vfs(PCIDevice *dev)
+     g_free(dev->exp.sriov_pf.vf);
+     dev->exp.sriov_pf.vf = NULL;
+     dev->exp.sriov_pf.num_vfs = 0;
++    pci_set_word(dev->wmask + dev->exp.sriov_cap + PCI_SRIOV_NUM_VF, 0xffff);
++}
++
++static void consume_config(PCIDevice *dev)
++{
++    uint8_t *cfg = dev->config + dev->exp.sriov_cap;
++
++    if (pci_get_word(cfg + PCI_SRIOV_CTRL) & PCI_SRIOV_CTRL_VFE) {
++        register_vfs(dev);
++    } else {
++        uint8_t *wmask = dev->wmask + dev->exp.sriov_cap;
++        uint16_t num_vfs = pci_get_word(cfg + PCI_SRIOV_NUM_VF);
++        uint16_t wmask_val = PCI_SRIOV_CTRL_MSE | PCI_SRIOV_CTRL_ARI;
++
++        unregister_vfs(dev);
++
++        if (num_vfs <= pci_get_word(cfg + PCI_SRIOV_TOTAL_VF)) {
++            wmask_val |= PCI_SRIOV_CTRL_VFE;
++        }
++
++        pci_set_word(wmask + PCI_SRIOV_CTRL, wmask_val);
++    }
+ }
+ 
+ void pcie_sriov_config_write(PCIDevice *dev, uint32_t address,
+@@ -234,17 +256,7 @@ void pcie_sriov_config_write(PCIDevice *dev, uint32_t address,
+     trace_sriov_config_write(dev->name, PCI_SLOT(dev->devfn),
+                              PCI_FUNC(dev->devfn), off, val, len);
+ 
+-    if (range_covers_byte(off, len, PCI_SRIOV_CTRL)) {
+-        if (dev->exp.sriov_pf.num_vfs) {
+-            if (!(val & PCI_SRIOV_CTRL_VFE)) {
+-                unregister_vfs(dev);
+-            }
+-        } else {
+-            if (val & PCI_SRIOV_CTRL_VFE) {
+-                register_vfs(dev);
+-            }
+-        }
+-    }
++    consume_config(dev);
+ }
+ 
+ 

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -446,7 +446,7 @@ Obsoletes: sgabios-bin <= 1:0.20180715git-10.fc38
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 9.1.0
-Release: 5%{?dist}
+Release: 6%{?dist}
 License: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND FSFAP AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND MIT AND LicenseRef-Fedora-Public-Domain AND CC-BY-3.0
 URL: http://www.qemu.org/
 
@@ -540,6 +540,7 @@ Patch58: 0055-hw-display-virtio-gpu-Manual-res-flush-to-redraw-sav.patch
 Patch59: 0056-hw-display-virtio-gpu-Properly-free-current_cursor.patch
 Patch60: 0057-ui-gtk-Re-grabbing-PTR-KBD-individually.patch
 Patch61: 0058-hw-usb-host-libusb-Do-not-assert-when-detects-invali.patch
+Patch62: pcie_sriov_CVE-2025-54567_CVE-2025-54566.patch
 
 BuildRequires: gnupg2
 BuildRequires: meson >= %{meson_version}
@@ -3538,6 +3539,10 @@ useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin \
 
 
 %changelog
+* Tue Jan 27 2025 Rajesh Shanmugam <rajesh1x.shanmugam@intel.com> - 9.1.0-6
+- Added 1 patch from Intel Distribution Qemu Commit 8e06d09
+- Add patch for CVE-2025-54566 CVE-2025-54567
+
 * Thu Oct 30 2025 Liang Yang <liang1.yang@intel.com> - 9.1.0-5
 - Added 1 patch from Intel Distribution Qemu Commit 3fbf5c5
 - Fix assert in qemu host-libusb when altsetting invalid


### PR DESCRIPTION
Add patch for CVE-2025-54566 CVE-2025-54567

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
[Black Duck] Security vulnerabilities (https://github.com/advisories/GHSA-399m-rf4f-w5x4, https://github.com/advisories/GHSA-c2q6-w8rj-wvhw) were detected in qemu-9.1.0-5.emt3.
QEMU has been upgraded to resolve the reported issues.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Created rpm and uploaded to BDBA scan along with BDBA config and found no CVEs.
<img width="1892" height="809" alt="image" src="https://github.com/user-attachments/assets/cbc8c687-2847-41bb-a4c7-cb00d2a44c33" />
