### PR TITLE
Remove i915.force_probe from kernel commandline

### DIFF
--- a/toolkit/imageconfigs/edge-image-dev.json
+++ b/toolkit/imageconfigs/edge-image-dev.json
@@ -108,7 +108,7 @@
                 }
             ],
             "KernelCommandLine": {
-                "ExtraCommandLine": "quiet splash sysctl.vm.overcommit_memory=1 sysctl.kernel.panic=10 sysctl.kernel.panic_on_oops=1 sysctl.fs.inotify.max_user_instances=8192 rd.shell=0 rd.parallel=1 rd.timeout=200 rd.emergency=reboot i915.force_probe=*",
+                "ExtraCommandLine": "quiet splash sysctl.vm.overcommit_memory=1 sysctl.kernel.panic=10 sysctl.kernel.panic_on_oops=1 sysctl.fs.inotify.max_user_instances=8192 rd.shell=0 rd.parallel=1 rd.timeout=200 rd.emergency=reboot",
                 "SELinux": "permissive"
             },
             "Hostname": "EdgeMicrovisorToolkit",

--- a/toolkit/imageconfigs/edge-image-rt-dev.json
+++ b/toolkit/imageconfigs/edge-image-rt-dev.json
@@ -108,7 +108,7 @@
                 }
             ],
             "KernelCommandLine": {
-                "ExtraCommandLine": "quiet splash idle=poll sysctl.vm.overcommit_memory=1 sysctl.kernel.panic=10 sysctl.kernel.panic_on_oops=1 sysctl.fs.inotify.max_user_instances=8192 rd.shell=0 rd.timeout=200 rd.emergency=reboot i915.force_probe=*",
+                "ExtraCommandLine": "quiet splash idle=poll sysctl.vm.overcommit_memory=1 sysctl.kernel.panic=10 sysctl.kernel.panic_on_oops=1 sysctl.fs.inotify.max_user_instances=8192 rd.shell=0 rd.timeout=200 rd.emergency=reboot",
                 "SELinux": "permissive"
             },
             "Hostname": "EdgeMicrovisorToolkit",

--- a/toolkit/imageconfigs/edge-image-rt.json
+++ b/toolkit/imageconfigs/edge-image-rt.json
@@ -105,7 +105,7 @@
                 }
             ],
             "KernelCommandLine": {
-                "ExtraCommandLine": "quiet splash idle=poll sysctl.vm.overcommit_memory=1 sysctl.kernel.panic=10 sysctl.kernel.panic_on_oops=1 sysctl.fs.inotify.max_user_instances=8192 rd.shell=0 rd.timeout=200 rd.emergency=reboot i915.force_probe=*",
+                "ExtraCommandLine": "quiet splash idle=poll sysctl.vm.overcommit_memory=1 sysctl.kernel.panic=10 sysctl.kernel.panic_on_oops=1 sysctl.fs.inotify.max_user_instances=8192 rd.shell=0 rd.timeout=200 rd.emergency=reboot",
                 "SELinux": "permissive"
             },
             "Hostname": "EdgeMicrovisorToolkit",

--- a/toolkit/imageconfigs/edge-image.json
+++ b/toolkit/imageconfigs/edge-image.json
@@ -105,7 +105,7 @@
                 }
             ],
             "KernelCommandLine": {
-                "ExtraCommandLine": "quiet splash sysctl.vm.overcommit_memory=1 sysctl.kernel.panic=10 sysctl.kernel.panic_on_oops=1 sysctl.fs.inotify.max_user_instances=8192 rd.shell=0 rd.parallel=1 rd.timeout=200 rd.emergency=reboot i915.force_probe=*",
+                "ExtraCommandLine": "quiet splash sysctl.vm.overcommit_memory=1 sysctl.kernel.panic=10 sysctl.kernel.panic_on_oops=1 sysctl.fs.inotify.max_user_instances=8192 rd.shell=0 rd.parallel=1 rd.timeout=200 rd.emergency=reboot",
                 "SELinux": "permissive"
             },
             "Hostname": "EdgeMicrovisorToolkit",

--- a/toolkit/imageconfigs/full.json
+++ b/toolkit/imageconfigs/full.json
@@ -19,7 +19,7 @@
                 "packagelists/kernel-rt-drivers.json"
             ],
             "KernelCommandLine": {
-                "ExtraCommandLine": "console=ttyS0,115200n8 console=tty0 i915.force_probe=*",
+                "ExtraCommandLine": "console=ttyS0,115200n8 console=tty0",
                 "SELinux": "permissive"
             },
             "KernelOptions": {
@@ -55,7 +55,7 @@
                 "packagelists/kernel-drivers.json"
             ],
             "KernelCommandLine": {
-                "ExtraCommandLine": "console=ttyS0,115200n8 console=tty0 i915.force_probe=*",
+                "ExtraCommandLine": "console=ttyS0,115200n8 console=tty0",
                 "SELinux": "permissive"
             },
             "KernelOptions": {
@@ -91,7 +91,7 @@
                 "packagelists/kernel-rt-drivers.json"
             ],
             "KernelCommandLine": {
-                "ExtraCommandLine": "console=ttyS0,115200n8 console=tty0 i915.force_probe=*",
+                "ExtraCommandLine": "console=ttyS0,115200n8 console=tty0",
                 "SELinux": "permissive"
             },
             "KernelOptions": {
@@ -126,7 +126,7 @@
                 "packagelists/kernel-drivers.json"
             ],
             "KernelCommandLine": {
-                "ExtraCommandLine": "console=ttyS0,115200n8 console=tty0 i915.force_probe=*",
+                "ExtraCommandLine": "console=ttyS0,115200n8 console=tty0",
                 "SELinux": "permissive"
             },
             "KernelOptions": {


### PR DESCRIPTION
Remove i915.force_probe from kernel commandline
- full.json
- rt and non-rt image

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
PTL is using XE instead of i915. hence removing i915.force_probe from commandline
<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Build on CI and check the kernel command line is updated 