### PR TITLE
CVE Fix for x-crypto component in caddy: next branch

### DIFF
--- a/SPECS/caddy/CVE-2025-47913.patch
+++ b/SPECS/caddy/CVE-2025-47913.patch
@@ -1,0 +1,51 @@
+From 559e062ce8bfd6a39925294620b50906ca2a6f95 Mon Sep 17 00:00:00 2001
+From: Nicola Murino <nicola.murino@gmail.com>
+Date: Sun, 31 Aug 2025 20:07:32 +0200
+Subject: [PATCH] ssh/agent: return an error for unexpected message types
+
+Previously, receiving an unexpected message type in response to a key
+listing or a signing request could cause a panic due to a failed type
+assertion.
+
+This change adds a default case to the type switch in order to detect
+and explicitly handle unknown or invalid message types, returning a
+descriptive error instead of crashing.
+
+Fixes golang/go#75178
+
+Change-Id: Icbc3432adc79fe3c56b1ff23c6724d7a6f710f3a
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/700295
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Reviewed-by: Michael Pratt <mpratt@google.com>
+Reviewed-by: Jakub Ciolek <jakub@ciolek.dev>
+---
+ vendor/golang.org/x/crypto/ssh/agent/client.go      |  6 +++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/vendor/golang.org/x/crypto/ssh/agent/client.go b/vendor/golang.org/x/crypto/ssh/agent/client.go
+index 37525e1a18..b357e18b0a 100644
+--- a/vendor/golang.org/x/crypto/ssh/agent/client.go
++++ b/vendor/golang.org/x/crypto/ssh/agent/client.go
+@@ -430,8 +430,9 @@ func (c *client) List() ([]*Key, error) {
+ 		return keys, nil
+ 	case *failureAgentMsg:
+ 		return nil, errors.New("agent: failed to list keys")
++	default:
++		return nil, fmt.Errorf("agent: failed to list keys, unexpected message type %T", msg)
+ 	}
+-	panic("unreachable")
+ }
+ 
+ // Sign has the agent sign the data using a protocol 2 key as defined
+@@ -462,8 +463,9 @@ func (c *client) SignWithFlags(key ssh.PublicKey, data []byte, flags SignatureFl
+ 		return &sig, nil
+ 	case *failureAgentMsg:
+ 		return nil, errors.New("agent: failed to sign challenge")
++	default:
++		return nil, fmt.Errorf("agent: failed to sign challenge, unexpected message type %T", msg)
+ 	}
+-	panic("unreachable")
+ }
+ 
+ // unmarshal parses an agent message in packet, returning the parsed

--- a/SPECS/caddy/CVE-2025-47914.patch
+++ b/SPECS/caddy/CVE-2025-47914.patch
@@ -1,0 +1,37 @@
+From f91f7a7c31bf90b39c1de895ad116a2bacc88748 Mon Sep 17 00:00:00 2001
+From: Neal Patel <nealpatel@google.com>
+Date: Wed, 10 Sep 2025 14:27:42 -0400
+Subject: [PATCH] ssh/agent: prevent panic on malformed constraint
+
+An attacker could supply a malformed Constraint that
+would trigger a panic in a serving agent, effectively
+causing denial of service.
+
+Thank you to Jakub Ciolek for reporting this issue.
+
+Fixes CVE-2025-47914
+Fixes golang/go#76364
+
+Change-Id: I195bbc68b1560d4f04897722a6a653a7cbf086eb
+Reviewed-on: https://go-review.googlesource.com/c/crypto/+/721960
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Auto-Submit: Roland Shoemaker <roland@golang.org>
+Reviewed-by: Damien Neil <dneil@google.com>
+---
+ vendor/golang.org/x/crypto/ssh/agent/server.go      | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/vendor/golang.org/x/crypto/ssh/agent/server.go b/vendor/golang.org/x/crypto/ssh/agent/server.go
+index 88ce4da6c4..4e8ff86b61 100644
+--- a/vendor/golang.org/x/crypto/ssh/agent/server.go
++++ b/vendor/golang.org/x/crypto/ssh/agent/server.go
+@@ -203,6 +203,9 @@ func parseConstraints(constraints []byte) (lifetimeSecs uint32, confirmBeforeUse
+ 	for len(constraints) != 0 {
+ 		switch constraints[0] {
+ 		case agentConstrainLifetime:
++			if len(constraints) < 5 {
++				return 0, false, nil, io.ErrUnexpectedEOF
++			}
+ 			lifetimeSecs = binary.BigEndian.Uint32(constraints[1:5])
+ 			constraints = constraints[5:]
+ 		case agentConstrainConfirm:

--- a/SPECS/caddy/caddy.spec
+++ b/SPECS/caddy/caddy.spec
@@ -3,7 +3,7 @@
 Summary:        Web server with automatic HTTPS
 Name:           caddy
 Version:        2.9.1
-Release:        17%{?dist}
+Release:        18%{?dist}
 Distribution:   Edge Microvisor Toolkit
 Vendor:         Intel Corporation
 # main source code is Apache-2.0
@@ -33,6 +33,8 @@ Patch4:         CVE-2025-22872.patch
 Patch5:         CVE-2025-58181.patch
 Patch6:         CVE-2025-61727.patch
 Patch7:         CVE-2025-61729.patch
+Patch8:         CVE-2025-47913.patch
+Patch9:         CVE-2025-47914.patch
 # https://github.com/caddyserver/caddy/commit/2028da4e74cd41f0f7f94222c6599da1a371d4b8
 BuildRequires:  golang >= 1.24.4
 BuildRequires:  golang < 1.25
@@ -455,6 +457,9 @@ fi
 %{_datadir}/fish/vendor_completions.d/caddy.fish
 
 %changelog
+* Fri Jan 23 2026 Shalini Singhal <shalinix.singhal@intel.com> - 2.9.1-18
+- Include patch for CVE-2025-47913, CVE-2025-41914
+
 * Tue Jan 22 2026 Polmoorx shiva kumar <polmoorx.shiva.kumar@intel.com> - 2.9.1-17
 - Include patch for CVE-2025-61727, CVE-2025-61729
 


### PR DESCRIPTION
- Applied suggested patch from NVD database for
   - CVE-2025-47913
   - CVE-2025-47914

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
CVE Fix for x-crypto component in caddy

Applied suggested patch from NVD database for
 - CVE-2025-47913
 - CVE-2025-47914
 
Cherry picked the change from 3.0-dev branch "5d866b667d20d5c193b0b1d8d3ae3f503ec24d56"

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
No

#### How Has This Been Tested? <!-- REQUIRED -->
