### PR TITLE
CVE Fix for otel-sdk component in otelcol-contrib

### DIFF
--- a/SPECS/otelcol-contrib/CVE-2026-24051.patch
+++ b/SPECS/otelcol-contrib/CVE-2026-24051.patch
@@ -1,0 +1,47 @@
+From d45961bcda453fcbdb6469c22d6e88a1f9970a53 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Robert=20Paj=C4=85k?= <pellared@hotmail.com>
+Date: Wed, 21 Jan 2026 18:33:00 +0100
+Subject: [PATCH] resource: specify full path for ioreg command in Darwin host
+ ID reader (#7818)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Use full path when calling `ioreg` to mitigate potential malicious code
+execution in case of [Path
+Interception](https://attack.mitre.org/techniques/T1574/007/).
+
+Note that path interception typically requires the attacker to influence
+the environment or place a malicious executable earlier in $PATH, which,
+in this context, generally implies the script itself would need to be
+introduced/uploaded (or otherwise placed/executed) in the target
+environment for the attacker’s substitute `ioreg` to be reached during
+execution.
+
+Reference:
+- https://cwe.mitre.org/data/definitions/426.html
+---
+ _build/vendor/go.opentelemetry.io/otel/sdk/resource/host_id.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/_build/vendor/go.opentelemetry.io/otel/sdk/resource/host_id.go b/_build/vendor/go.opentelemetry.io/otel/sdk/resource/host_id.go
+index 25778c99a..f8addf040 100644
+--- a/_build/vendor/go.opentelemetry.io/otel/sdk/resource/host_id.go
++++ b/_build/vendor/go.opentelemetry.io/otel/sdk/resource/host_id.go
+@@ -51,11 +51,11 @@ type hostIDReaderDarwin struct {
+ 	execCommand commandExecutor
+ }
+ 
+-// read executes `ioreg -rd1 -c "IOPlatformExpertDevice"` and parses host id
++// read executes `/usr/sbin/ioreg -rd1 -c "IOPlatformExpertDevice"` and parses host id
+ // from the IOPlatformUUID line. If the command fails or the uuid cannot be
+ // parsed an error will be returned.
+ func (r *hostIDReaderDarwin) read() (string, error) {
+-	result, err := r.execCommand("ioreg", "-rd1", "-c", "IOPlatformExpertDevice")
++	result, err := r.execCommand("/usr/sbin/ioreg", "-rd1", "-c", "IOPlatformExpertDevice")
+ 	if err != nil {
+ 		return "", err
+ 	}
+-- 
+2.34.1
+

--- a/SPECS/otelcol-contrib/otelcol-contrib.spec
+++ b/SPECS/otelcol-contrib/otelcol-contrib.spec
@@ -1,7 +1,7 @@
 Summary:        OpenTelemetry Collector Contrib
 Name:           otelcol-contrib
 Version:        0.141.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        Apache-2.0
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -11,6 +11,7 @@ URL:            https://github.com/open-telemetry/opentelemetry-collector-releas
 Source0:        %{url}/releases/download/v%{version}/%{name}_%{version}_linux_amd64.tar.gz#/%{name}-%{version}-vendored.tar.gz
 Source1:        otelcol_contrib.te
 Source2:        otelcol_contrib.fc
+Patch1:         CVE-2026-24051.patch
 BuildRequires:  golang < 1.26
 BuildRequires:  golang >= 1.25.5
 BuildRequires:  make
@@ -68,6 +69,9 @@ install -m 644 %{modulename}.pp %{buildroot}%{_datadir}/selinux/packages/%{modul
 %selinux_modules_uninstall -s %{selinuxtype} %{modulename}
 
 %changelog
+* Tue Mar 10 2026 Shalini Singhal <shalinix.singhal@intel.com> - 0.141.0-3
+- Added patch to fix CVE-2026-24051
+
 * Fri Feb 20 2025 Basavarajx unniche <basavarajx.unniche@intel.com> - 0.141.0-2
 - Upgrade golang version to use 1.25.7
 


### PR DESCRIPTION
CVE Fix for otel-sdk component in otelcol-contrib.  
  - Applied suggested patch from NVD database for - CVE-2026-24051

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
CVE Fix for otel-sdk component in otelcol-contrib.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
No

#### How Has This Been Tested? <!-- REQUIRED -->
Manually tested.
