### PR TITLE
[ICT] - base template for emt iso images

### DIFF
--- a/toolkit/imageconfigs/emt3-x86_64-rt-kernel-docker-iso.yml
+++ b/toolkit/imageconfigs/emt3-x86_64-rt-kernel-docker-iso.yml
@@ -1,0 +1,66 @@
+image:
+  name: emt3-x86_64-rt-kernel-docker
+  version: "1.0.0"
+
+target:
+  os: edge-microvisor-toolkit
+  dist: emt3
+  arch: x86_64
+  imageType: iso
+
+disk:
+  name: RT-Kernel-Docker
+  partitionTableType: gpt # Partition table type, valid value: [gpt, mbr]
+  partitions: # Required for raw, optional for ISO, not needed for rootfs.
+    - id: boot
+      type: esp
+      flags:
+        - esp
+        - boot
+      start: 1MiB
+      end: 9MiB
+      fsType: fat32
+      mountPoint: /boot/efi
+
+    - id: rootfs
+      type: linux-root-amd64
+      start: 9MiB
+      end: "0"  # 0 means use the rest of the disk space
+      fsType: ext4
+      mountPoint: /
+
+systemConfig:
+  name: RT-Kernel-Docker
+  description: RT kernel configuration with Docker
+
+  packages:
+    # developer packages
+    - alsa-sof-firmware
+
+    # intel gpu base
+    - kernel-rt-drivers-gpu
+    - intel-npu-driver
+
+    # kernel drivers
+    - kernel-rt-drivers-sound
+
+    # intel rtd
+    - intel-cmt-cat
+    - intel-cmt-cat-devel
+
+    # docker
+    - moby-engine
+    - docker-cli
+    - docker-compose
+
+  kernel:
+    name: kernel-rt
+    cmdline: "console=ttyS0,115200n8 console=tty0 i915.force_probe=*"
+    packages:
+      - kernel-rt
+
+  additionalFiles:
+    - local: additionalconfigs/configure-systemd-networkd-client-identifier.sh
+      final: /tmp/configure-systemd-networkd-client-identifier.sh
+    - local: additionalconfigs/configure-ip4save.sh
+      final: /tmp/configure-ip4save.sh

--- a/toolkit/imageconfigs/emt3-x86_64-rt-kernel-iso.yml
+++ b/toolkit/imageconfigs/emt3-x86_64-rt-kernel-iso.yml
@@ -1,0 +1,61 @@
+image:
+  name: emt3-x86_64-rt-kernel
+  version: "1.0.0"
+
+target:
+  os: edge-microvisor-toolkit
+  dist: emt3
+  arch: x86_64
+  imageType: iso
+
+disk:
+  name: RT-Kernel
+  partitionTableType: gpt # Partition table type, valid value: [gpt, mbr]
+  partitions: # Required for raw, optional for ISO, not needed for rootfs.
+    - id: boot
+      type: esp
+      flags:
+        - esp
+        - boot
+      start: 1MiB
+      end: 9MiB
+      fsType: fat32
+      mountPoint: /boot/efi
+
+    - id: rootfs
+      type: linux-root-amd64
+      start: 9MiB
+      end: "0"  # 0 means use the rest of the disk space
+      fsType: ext4
+      mountPoint: /
+
+systemConfig:
+  name: RT-Kernel
+  description: RT kernel configuration
+
+  packages:
+    # developer packages
+    - alsa-sof-firmware
+
+    # intel gpu base
+    - kernel-rt-drivers-gpu
+    - intel-npu-driver
+
+    # kernel drivers
+    - kernel-rt-drivers-sound
+
+    # intel rtd
+    - intel-cmt-cat
+    - intel-cmt-cat-devel
+
+  kernel:
+    name: kernel-rt
+    cmdline: "console=ttyS0,115200n8 console=tty0 i915.force_probe=*"
+    packages:
+      - kernel-rt
+
+  additionalFiles:
+    - local: additionalconfigs/configure-systemd-networkd-client-identifier.sh
+      final: /tmp/configure-systemd-networkd-client-identifier.sh
+    - local: additionalconfigs/configure-ip4save.sh
+      final: /tmp/configure-ip4save.sh

--- a/toolkit/imageconfigs/emt3-x86_64-standard-kernel-docker-iso.yml
+++ b/toolkit/imageconfigs/emt3-x86_64-standard-kernel-docker-iso.yml
@@ -1,0 +1,62 @@
+image:
+  name: emt3-x86_64-standard-kernel-docker
+  version: "1.0.0"
+
+target:
+  os: edge-microvisor-toolkit
+  dist: emt3
+  arch: x86_64
+  imageType: iso
+
+disk:
+  name: Standard-Kernel-Docker
+  partitionTableType: gpt # Partition table type, valid value: [gpt, mbr]
+  partitions: # Required for raw, optional for ISO, not needed for rootfs.
+    - id: boot
+      type: esp
+      flags:
+        - esp
+        - boot
+      start: 1MiB
+      end: 9MiB
+      fsType: fat32
+      mountPoint: /boot/efi
+
+    - id: rootfs
+      type: linux-root-amd64
+      start: 9MiB
+      end: "0"  # 0 means use the rest of the disk space
+      fsType: ext4
+      mountPoint: /
+
+systemConfig:
+  name: Standard-Kernel-Docker
+  description: Standard kernel configuration with Docker
+
+  packages:
+    # developer packages
+    - alsa-sof-firmware
+
+    # intel gpu base
+    - kernel-drivers-gpu
+    - intel-npu-driver
+
+    # kernel drivers
+    - kernel-drivers-sound
+
+    # docker
+    - moby-engine
+    - docker-cli
+    - docker-compose
+
+  kernel:
+    name: kernel
+    cmdline: "console=ttyS0,115200n8 console=tty0 i915.force_probe=*"
+    packages:
+      - kernel
+
+  additionalFiles:
+    - local: additionalconfigs/configure-systemd-networkd-client-identifier.sh
+      final: /tmp/configure-systemd-networkd-client-identifier.sh
+    - local: additionalconfigs/configure-ip4save.sh
+      final: /tmp/configure-ip4save.sh

--- a/toolkit/imageconfigs/emt3-x86_64-standard-kernel-iso.yml
+++ b/toolkit/imageconfigs/emt3-x86_64-standard-kernel-iso.yml
@@ -1,0 +1,57 @@
+image:
+  name: emt3-x86_64-standard-kernel
+  version: "1.0.0"
+
+target:
+  os: edge-microvisor-toolkit
+  dist: emt3
+  arch: x86_64
+  imageType: iso
+
+disk:
+  name: Standard-Kernel
+  partitionTableType: gpt # Partition table type, valid value: [gpt, mbr]
+  partitions: # Required for raw, optional for ISO, not needed for rootfs.
+    - id: boot
+      type: esp
+      flags:
+        - esp
+        - boot
+      start: 1MiB
+      end: 9MiB
+      fsType: fat32
+      mountPoint: /boot/efi
+
+    - id: rootfs
+      type: linux-root-amd64
+      start: 9MiB
+      end: "0"  # 0 means use the rest of the disk space
+      fsType: ext4
+      mountPoint: /
+
+systemConfig:
+  name: Standard-Kernel
+  description: Standard kernel configuration
+
+  packages:
+    # developer packages
+    - alsa-sof-firmware
+
+    # intel gpu base
+    - kernel-drivers-gpu
+    - intel-npu-driver
+
+    # kernel drivers
+    - kernel-drivers-sound
+
+  kernel:
+    name: kernel
+    cmdline: "console=ttyS0,115200n8 console=tty0 i915.force_probe=*"
+    packages:
+      - kernel
+
+  additionalFiles:
+    - local: additionalconfigs/configure-systemd-networkd-client-identifier.sh
+      final: /tmp/configure-systemd-networkd-client-identifier.sh
+    - local: additionalconfigs/configure-ip4save.sh
+      final: /tmp/configure-ip4save.sh


### PR DESCRIPTION
- Added yml for iso image flavours based on existing template from ICT.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Yml template files needed for generation of emt iso images through image compressor tool.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Created image using these templates in os-image-composer repo and loaded to DELL server. Server is booted up without any issues.
NOTE:
Changes to the default YAML were necessary in ICT repo to separate the base configuration from flavor-specific components and prevent unintended inclusion across all builds.
