### PR TITLE
docs: allow toolchain rebuild on full rebuild

### DIFF
--- a/docs/developer-guide/get-started/emt-build-and-deploy.md
+++ b/docs/developer-guide/get-started/emt-build-and-deploy.md
@@ -177,7 +177,7 @@ For example, to build a RAW image without real-time extensions, use `edge-image.
 
    ```bash
    # Rebuild packages/RPMs local toolchain
-   sudo make build-packages REBUILD_TOOLS=y VALIDATE_TOOLCHAIN_GPG=n
+   sudo make build-packages REBUILD_TOOLS=y VALIDATE_TOOLCHAIN_GPG=n ALLOW_TOOLCHAIN_REBUILDS=y
    ```
 
 8. Build the toolkit image:

--- a/docs/developer-guide/get-started/emt-building-howto.md
+++ b/docs/developer-guide/get-started/emt-building-howto.md
@@ -73,7 +73,7 @@ git clone https://github.com/open-edge-platform/edge-microvisor-toolkit --branch
 
    ```bash
    # Rebuild packages/RPMs
-   sudo make build-packages REBUILD_TOOLS=y VALIDATE_TOOLCHAIN_GPG=n
+   sudo make build-packages REBUILD_TOOLS=y VALIDATE_TOOLCHAIN_GPG=n ALLOW_TOOLCHAIN_REBUILDS=y
    ```
 
 ## Build the Edge Microvisor Toolkit Image


### PR DESCRIPTION
rebased on Azure Linux 20260304 is causing toolchain to rebuild during build-packages on full build, this is expected hence set flag to allow it.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
