### PR TITLE
Upgrade gstreamer to 1.28.1 version.

### DIFF
--- a/SPECS/gstreamer1-plugins-base/gstreamer1-plugins-base.signatures.json
+++ b/SPECS/gstreamer1-plugins-base/gstreamer1-plugins-base.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "gst-plugins-base-1.26.5.tar.xz": "f0c0e26cbedaa57732cb6a578e8cc13a1164bf18d737d55c333061c52f0c48d7"
+  "gst-plugins-base-1.28.1.tar.xz": "1446a4c2a92ff5d78d88e85a599f0038441d53333236f0c72d72f21a9c132497"
  }
 }

--- a/SPECS/gstreamer1-plugins-base/gstreamer1-plugins-base.spec
+++ b/SPECS/gstreamer1-plugins-base/gstreamer1-plugins-base.spec
@@ -2,8 +2,8 @@
 %global         majorminor      1.0
 Summary:        GStreamer streaming media framework base plugins
 Name:           gstreamer1-plugins-base
-Version:        1.26.5
-Release:        2%{?dist}
+Version:        1.28.1
+Release:        1%{?dist}
 License:        LGPLv2+
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -426,6 +426,9 @@ rm %{_libexecdir}/gstreamer-%{majorminor}/gst-plugin-scanner
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Thu Apr 02 2026 Basavarajx unniche <basavarajx.unniche@intel.com> - 1.28.1-1
+- Upgrade to gstreamer version.
+
 * Mon Oct 13 2025 Swee Yee Fonn <swee.yee.fonn@intel.com> - 1.26.5-2
 - Upgrading to 1.26.5 based on Fedora 44 (license: MIT) for guidance.
 

--- a/SPECS/gstreamer1/gstreamer1.signatures.json
+++ b/SPECS/gstreamer1/gstreamer1.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "gstreamer-1.26.5.tar.xz": "0a7edb0e7b42dbe6b575fce61a4808a3f6b20e085a1eaecbc025d0ec21f1e774",
+  "gstreamer-1.28.1.tar.xz": "b65e2ffa35bdbf8798cb75c23ffc3d05e484e48346ff7546844ba85217664504",
   "gstreamer1.attr": "340f3a82ccd5f005e503a498b67df82d731cccf8d7eeb4d5627a62d443785b37",
   "gstreamer1.prov": "ccf26099c6413e2d4acc3bc22ad75c4e0954d09965ea47c888b5374705f881ba"
  }

--- a/SPECS/gstreamer1/gstreamer1.spec
+++ b/SPECS/gstreamer1/gstreamer1.spec
@@ -7,7 +7,7 @@
 
 Summary:        GStreamer streaming media framework runtime
 Name:           gstreamer1
-Version:        1.26.5
+Version:        1.28.1
 Release:        1%{?dist}
 License:        LGPLv2+
 Vendor:         Intel Corporation
@@ -170,6 +170,9 @@ install -m0644 -D %{SOURCE2} $RPM_BUILD_ROOT%{_rpmconfigdir}/fileattrs/gstreamer
 %{_datadir}/cmake/FindGStreamer.cmake
 
 %changelog
+* Thu Apr 02 2026 Basavarajx unniche <basavarajx.unniche@intel.com> - 1.28.1-1
+- Upgrade version to fix CVE-2026-3083 and CVE-2026-3085.
+
 * Mon Oct 06 2025 Swee Yee Fonn <swee.yee.fonn@intel.com> - 1.26.5-1
 - Initial Edge Microvisor Toolkit import from Azure Linux (license: MIT)
 - License verified.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -5120,8 +5120,8 @@
         "type": "other",
         "other": {
           "name": "gstreamer1",
-          "version": "1.26.5",
-          "downloadUrl": "http://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.26.5.tar.xz"
+          "version": "1.28.1",
+          "downloadUrl": "http://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.28.1.tar.xz"
         }
       }
     },
@@ -5130,8 +5130,8 @@
         "type": "other",
         "other": {
           "name": "gstreamer1-plugins-base",
-          "version": "1.26.5",
-          "downloadUrl": "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-1.26.5.tar.xz"
+          "version": "1.28.1",
+          "downloadUrl": "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-1.28.1.tar.xz"
         }
       }
     },


### PR DESCRIPTION
 - upgraded version to fix CVE-2026-3083 and CVE-2026-3085.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [] The changes in the PR have been built and tested
- [X] cgmanifest file has been updated if required
- [ ] Ready to merge

#### Description <!-- REQUIRED -->
Upgrade gstreamer to fix `CVE-2026-3083` and `CVE-2026-3085`

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencieshttps://github.com/bunnichx/edge-microvisor-toolkit/pull/new/upgrade-gstreamer
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
