### PR TITLE
aarch64 support for nvidia-data-center-driver

### DIFF
--- a/SPECS/nvidia-data-center-driver/nvidia-data-center-driver.signatures.json
+++ b/SPECS/nvidia-data-center-driver/nvidia-data-center-driver.signatures.json
@@ -1,5 +1,6 @@
 {
  "Signatures": {
+  "NVIDIA-Linux-aarch64-570.133.20.run": "7e135f98be5d13afcc5f0ab23f4fdfd057364143b11bb6f4932f565534c89bd0",
   "NVIDIA-Linux-x86_64-570.133.20.run": "1253d17b1528e8a24bf1f34a8ac6591c924b98ad7a32344bde253aa622ac1605"
  }
 }

--- a/SPECS/nvidia-data-center-driver/nvidia-data-center-driver.spec
+++ b/SPECS/nvidia-data-center-driver/nvidia-data-center-driver.spec
@@ -12,7 +12,7 @@ Name:           nvidia-data-center-driver
 Version:        570.133.20
 Release:        16%{?dist}
 License:        Public Domain
-Source0:        https://us.download.nvidia.com/tesla/%{version}/NVIDIA-Linux-x86_64-%{version}.run
+Source0:        https://us.download.nvidia.com/tesla/%{version}/NVIDIA-Linux-%{_arch}-%{version}.run
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
 
@@ -28,29 +28,32 @@ This kernel driver package contains Nvidia data center GPU driver.
 %prep
 cp -p %{SOURCE0} .
 chmod 755 %{SOURCE0}
-rm -rf NVIDIA-Linux-x86_64-%{version}
-sh ./NVIDIA-Linux-x86_64-%{version}.run -x
+rm -rf NVIDIA-Linux-%{_arch}-%{version}
+sh ./NVIDIA-Linux-%{_arch}-%{version}.run -x
 
 %build
 export KERNEL_UNAME=%{kernel_ver}
 unset LDFLAGS
-cd NVIDIA-Linux-x86_64-%{version}/kernel
+cd NVIDIA-Linux-%{_arch}-%{version}/kernel
 make %{?_smp_mflags} modules
 
 %install
 export KERNEL_UNAME=%{kernel_ver}
-cd NVIDIA-Linux-x86_64-%{version}/kernel
+cd NVIDIA-Linux-%{_arch}-%{version}/kernel
 make INSTALL_MOD_PATH=%{buildroot} modules_install
 
 %files
 %defattr(-,root,root)
-%license NVIDIA-Linux-x86_64-%{version}/LICENSE
+%license NVIDIA-Linux-%{_arch}-%{version}/LICENSE
 /lib/modules/
 
 %post
 /sbin/depmod -a
 
 %changelog
+* Wed Apr 15 2026 Mateo Guzman <mateo.guzman@intel.com> - 570.133.20-17
+- Add aarch64 support
+
 * Thu Feb 05 2026 Lishan Liu <lishan.liu@intel.com> - 570.133.20-16
 - Bump release to rebuild
 

--- a/SPECS/nvidia-data-center-driver/nvidia-data-center-driver.spec
+++ b/SPECS/nvidia-data-center-driver/nvidia-data-center-driver.spec
@@ -10,7 +10,7 @@
 Summary:        nvidia gpu driver kernel module for data center devices
 Name:           nvidia-data-center-driver
 Version:        570.133.20
-Release:        16%{?dist}
+Release:        17%{?dist}
 License:        Public Domain
 Source0:        https://us.download.nvidia.com/tesla/%{version}/NVIDIA-Linux-%{_arch}-%{version}.run
 Vendor:         Intel Corporation


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [x] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description 

This pull request updates the `nvidia-data-center-driver` packaging to add support for the `aarch64` architecture, making the build process architecture-agnostic and improving compatibility for ARM-based systems. The changes generalize file and directory names to use the `%{_arch}` macro and add the appropriate signature for the new architecture.

Architecture support and build process updates:

* Updated `Source0` URL, file, and directory references in `nvidia-data-center-driver.spec` to use the `%{_arch}` macro, enabling support for both `x86_64` and `aarch64` architectures. This generalizes the build process and file handling to work with multiple architectures. 
* Added a changelog entry noting the addition of `aarch64` support.

Signature updates:

* Added the signature for `NVIDIA-Linux-aarch64-570.133.20.run` to `nvidia-data-center-driver.signatures.json` to support verification of the new architecture's installer.

#### How Has This Been Tested?

Local package build

