### PR TITLE
upgrade gstreamer to v1.28.1

### DIFF
--- a/SPECS/gstreamer1-plugins-base/gstreamer1-plugins-base.signatures.json
+++ b/SPECS/gstreamer1-plugins-base/gstreamer1-plugins-base.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "gst-plugins-base-1.26.10.tar.xz": "1c1531dd8f2d480c89c57b08a930545a3375077391789762e40e490cdbbf03fd"
+  "gst-plugins-base-1.28.1.tar.xz": "1446a4c2a92ff5d78d88e85a599f0038441d53333236f0c72d72f21a9c132497"
  }
 }

--- a/SPECS/gstreamer1-plugins-base/gstreamer1-plugins-base.spec
+++ b/SPECS/gstreamer1-plugins-base/gstreamer1-plugins-base.spec
@@ -2,7 +2,7 @@
 %global         majorminor      1.0
 Summary:        GStreamer streaming media framework base plugins
 Name:           gstreamer1-plugins-base
-Version:        1.26.10
+Version:        1.28.1
 Release:        1%{?dist}
 License:        LGPLv2+
 Vendor:         Intel Corporation
@@ -166,7 +166,7 @@ rm %{_libexecdir}/gstreamer-%{majorminor}/gst-plugin-scanner
 
 %files -f gst-plugins-base-%{majorminor}.lang
 %license COPYING
-%doc AUTHORS NEWS README.md README.static-linking RELEASE REQUIREMENTS
+%doc README.md README.static-linking RELEASE
 %{_datadir}/appdata/*.appdata.xml
 %{_libdir}/libgstallocators-%{majorminor}.so.*
 %{_libdir}/libgstaudio-%{majorminor}.so.*
@@ -250,6 +250,7 @@ rm %{_libexecdir}/gstreamer-%{majorminor}/gst-plugin-scanner
 %{_includedir}/gstreamer-%{majorminor}/gst/allocators/gstfdmemory.h
 %{_includedir}/gstreamer-%{majorminor}/gst/allocators/gstphysmemory.h
 %{_includedir}/gstreamer-%{majorminor}/gst/allocators/gstshmallocator.h
+%{_includedir}/gstreamer-%{majorminor}/gst/allocators/gstudmabufallocator.h
 %dir %{_includedir}/gstreamer-%{majorminor}/gst/app
 %{_includedir}/gstreamer-%{majorminor}/gst/app/app.h
 %{_includedir}/gstreamer-%{majorminor}/gst/app/app-prelude.h
@@ -391,6 +392,7 @@ rm %{_libexecdir}/gstreamer-%{majorminor}/gst-plugin-scanner
 %{_includedir}/gstreamer-%{majorminor}/gst/video/videodirection.h
 %{_includedir}/gstreamer-%{majorminor}/gst/video/videoorientation.h
 %{_includedir}/gstreamer-%{majorminor}/gst/video/videooverlay.h
+%{_includedir}/gstreamer-%{majorminor}/gst/video/gstvideodmabufpool.h
 
 %{_libdir}/libgstallocators-%{majorminor}.so
 %{_libdir}/libgstaudio-%{majorminor}.so
@@ -426,6 +428,9 @@ rm %{_libexecdir}/gstreamer-%{majorminor}/gst-plugin-scanner
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Tue Apr 14 2026 Basavarajx unniche <basavarajx.unniche@intel.com> - 1.28.1-1
+- Upgrade to gstreamer1 version.
+
 * Thu Mar 26 2026 Lishan Liu<lishan.liu@intel.com> - 1.26.10-1
 - Upgraded version 1.26.10
 

--- a/SPECS/gstreamer1/gstreamer1.signatures.json
+++ b/SPECS/gstreamer1/gstreamer1.signatures.json
@@ -1,6 +1,6 @@
 {
  "Signatures": {
-  "gstreamer-1.26.10.tar.xz": "d7f20bec75edeb8677662926c33e987da64a42616c24fc3353b9ad44ed750cd6",
+  "gstreamer-1.28.1.tar.xz": "b65e2ffa35bdbf8798cb75c23ffc3d05e484e48346ff7546844ba85217664504",
   "gstreamer1.attr": "340f3a82ccd5f005e503a498b67df82d731cccf8d7eeb4d5627a62d443785b37",
   "gstreamer1.prov": "ccf26099c6413e2d4acc3bc22ad75c4e0954d09965ea47c888b5374705f881ba"
  }

--- a/SPECS/gstreamer1/gstreamer1.spec
+++ b/SPECS/gstreamer1/gstreamer1.spec
@@ -7,7 +7,7 @@
 
 Summary:        GStreamer streaming media framework runtime
 Name:           gstreamer1
-Version:        1.26.10
+Version:        1.28.1
 Release:        1%{?dist}
 License:        LGPLv2+
 Vendor:         Intel Corporation
@@ -89,7 +89,7 @@ install -m0644 -D %{SOURCE2} $RPM_BUILD_ROOT%{_rpmconfigdir}/fileattrs/gstreamer
 
 %files -f gstreamer-%{majorminor}.lang
 %license COPYING
-%doc AUTHORS NEWS README.md README.static-linking RELEASE
+%doc README.md README.static-linking RELEASE
 %{_libdir}/libgstreamer-%{majorminor}.so.*
 %{_libdir}/libgstbase-%{majorminor}.so.*
 %{_libdir}/libgstcheck-%{majorminor}.so.*
@@ -170,6 +170,9 @@ install -m0644 -D %{SOURCE2} $RPM_BUILD_ROOT%{_rpmconfigdir}/fileattrs/gstreamer
 %{_datadir}/cmake/FindGStreamer.cmake
 
 %changelog
+* Tue Apr 14 2026 Basavarajx unniche <basavarajx.unniche@intel.com> - 1.28.1-1
+- Upgrade version to fix CVE-2026-3083 and CVE-2026-3085.
+
 * Wed Mar 25 2026 Lishan Liu<lishan.liu@intel.com> - 1.26.10-1
 - Upgraded version 1.26.10
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3140,8 +3140,8 @@
         "type": "other",
         "other": {
           "name": "gstreamer1",
-          "version": "1.26.10",
-          "downloadUrl": "http://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.26.10.tar.xz"
+          "version": "1.28.1",
+          "downloadUrl": "http://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.28.1.tar.xz"
         }
       }
     },
@@ -3150,8 +3150,8 @@
         "type": "other",
         "other": {
           "name": "gstreamer1-plugins-base",
-          "version": "1.26.10",
-          "downloadUrl": "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-1.26.10.tar.xz"
+          "version": "1.28.1",
+          "downloadUrl": "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-1.28.1.tar.xz"
         }
       }
     },


### PR DESCRIPTION
 - upgraded version to fix CVE-2026-3083 and CVE-2026-3085.
 - modified spec file according to new source.

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [X] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
Upgrade gstreamer to fix CVE-2026-3083 and CVE-2026-3085

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies


#### How Has This Been Tested? <!-- REQUIRED -->
Developer build with ID 1791 is success. 
<img width="500" height="102" alt="image" src="https://github.com/user-attachments/assets/b7c3f88e-ad3d-4121-acf6-4f1d18c6d067" />

