### PR TITLE
correct otelcol-contrib buildrequires to use latest go-lang version.

### DIFF
--- a/SPECS/otelcol-contrib/otelcol-contrib.spec
+++ b/SPECS/otelcol-contrib/otelcol-contrib.spec
@@ -1,7 +1,7 @@
 Summary:        OpenTelemetry Collector Contrib
 Name:           otelcol-contrib
 Version:        0.141.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        Apache-2.0
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -12,8 +12,8 @@ Source0:        %{url}/releases/download/v%{version}/%{name}_%{version}_linux_am
 Source1:        otelcol_contrib.te
 Source2:        otelcol_contrib.fc
 Patch0:         CVE-2026-32287.patch
-BuildRequires:  golang < 1.26
-BuildRequires:  golang >= 1.25.5
+BuildRequires:  golang < 1.27
+BuildRequires:  golang >= 1.26.2
 BuildRequires:  make
 BuildRequires:  systemd-rpm-macros
 Requires:       (%{name}-selinux if selinux-policy-targeted)
@@ -69,6 +69,9 @@ install -m 644 %{modulename}.pp %{buildroot}%{_datadir}/selinux/packages/%{modul
 %selinux_modules_uninstall -s %{selinuxtype} %{modulename}
 
 %changelog
+* Thu May 7 2026 Basavarajx unniche <basavarajx.unniche@intel.com> - 0.141.0-4
+- upgrade golang version to fix golang-runtime cve vulnerabilities
+
 * Mon May 4 2026 Jing Hui Tham <jing.hui.tham@intel.com> - 0.141.0-3
 - Fix CVE-2026-32287
 


### PR DESCRIPTION
- bumped builrequires to use latest go-lang version to fix
- golang-runtime component CVE vulnerabilites reported.
- Fixes CVE-2026-32288,CVE-2026-32289,CVE-2026-32282,
- CVE-2026-27144, CVE-2026-27140, CVE-2026-32283 and CVE-2026-27143

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
use latest golang version available in EMT to resolve CVE's reported on older version.

<!-- Fixes # (issue) -->
CVE's associated with go-lang 1.25.7 version.

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
Developer build with #1866 is success. 
