### PR TITLE
Remove one i915 patch to resolve duplicate entry issue

### DIFF
--- a/SPECS/kernel-headers/kernel-headers.spec
+++ b/SPECS/kernel-headers/kernel-headers.spec
@@ -14,7 +14,7 @@
 Summary:        Linux API header files
 Name:           kernel-headers
 Version:        6.18.20
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -76,6 +76,9 @@ done
 %endif
 
 %changelog
+* Wed May 13 2026 Lishan Liu <lishan.liu@intel.com> - 6.18.20-2
+- Bump release version for rebuild
+
 * Wed Apr 29 2026 Lishan Liu <lishan.liu@intel.com> - 6.18.20-1
 - Update kernel to 6.18.20-1
 - lts-v6.18.20-emt-cve-260417T093242Z

--- a/SPECS/kernel-rt/kernel-rt.spec
+++ b/SPECS/kernel-rt/kernel-rt.spec
@@ -1,7 +1,7 @@
 Summary:        Preempt RT Linux Kernel
 Name:           kernel-rt
 Version:        6.18.20
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -239,7 +239,6 @@ Patch07071: 0064-drm-i915-gt-Isolate-single-sysfs-engine-file-creation.drm
 Patch07072: 0065-drm-i915-gt-Implement-creation-and-removal-routines-fo.drm
 Patch07073: 0066-drm-i915-gt-Allow-the-user-to-change-the-CCS-mode-thro.drm
 Patch07074: 0067-drm-i915-gt-Refactor-CCS-mode-handling-and-improve-app.drm
-Patch07075: 0068-drm-i915-no-waiting-for-page-flip-in-vpp-case.drm
 Patch07076: 0069-drm-i915-move-sriov-selftest-buffer-out-of-stack.drm
 Patch07077: 0001-drm-virtio-Wait-until-the-control-and-cursor-queues-ar.drm
 Patch07078: 0002-virtio-gpu-reset-attachment-state-during-resource-rest.drm
@@ -856,6 +855,9 @@ ln -sf linux-%{uname_r}.cfg /boot/mariner.cfg
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Wed May 13 2026 Lishan Liu <lishan.liu@intel.com> - 6.18.20-2
+- Remove patch 0068-drm-i915-no-waiting-for-page-flip-in-vpp-case.drm
+
 * Wed Apr 29 2026 Lishan Liu <lishan.liu@intel.com> - 6.18.20-1
 - Update kernel to 6.18.20-1
 - lts-v6.18.20-emt-cve-260417T093242Z

--- a/SPECS/kernel/kernel-uki.spec
+++ b/SPECS/kernel/kernel-uki.spec
@@ -13,7 +13,7 @@
 Summary:        Unified Kernel Image
 Name:           kernel-uki
 Version:        6.18.20
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -70,6 +70,9 @@ cp %{buildroot}/boot/vmlinuz-uki-%{kernelver}.efi %{buildroot}/boot/efi/EFI/Linu
 /boot/efi/EFI/Linux/vmlinuz-uki-%{kernelver}.efi
 
 %changelog
+* Wed May 13 2026 Lishan Liu <lishan.liu@intel.com> - 6.18.20-2
+- Remove patch 0068-drm-i915-no-waiting-for-page-flip-in-vpp-case.drm
+
 * Wed Apr 29 2026 Lishan Liu <lishan.liu@intel.com> - 6.18.20-1
 - Update kernel to 6.18.20-1
 - lts-v6.18.20-emt-cve-260417T093242Z

--- a/SPECS/kernel/kernel.spec
+++ b/SPECS/kernel/kernel.spec
@@ -1,7 +1,7 @@
 Summary:        Linux Kernel
 Name:           kernel
 Version:        6.18.20
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPLv2
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
@@ -239,7 +239,6 @@ Patch07071: 0064-drm-i915-gt-Isolate-single-sysfs-engine-file-creation.drm
 Patch07072: 0065-drm-i915-gt-Implement-creation-and-removal-routines-fo.drm
 Patch07073: 0066-drm-i915-gt-Allow-the-user-to-change-the-CCS-mode-thro.drm
 Patch07074: 0067-drm-i915-gt-Refactor-CCS-mode-handling-and-improve-app.drm
-Patch07075: 0068-drm-i915-no-waiting-for-page-flip-in-vpp-case.drm
 Patch07076: 0069-drm-i915-move-sriov-selftest-buffer-out-of-stack.drm
 Patch07077: 0001-drm-virtio-Wait-until-the-control-and-cursor-queues-ar.drm
 Patch07078: 0002-virtio-gpu-reset-attachment-state-during-resource-rest.drm
@@ -831,6 +830,9 @@ echo "initrd of kernel %{uname_r} removed" >&2
 %{_sysconfdir}/bash_completion.d/bpftool
 
 %changelog
+* Wed May 13 2026 Lishan Liu <lishan.liu@intel.com> - 6.18.20-2
+- Remove patch 0068-drm-i915-no-waiting-for-page-flip-in-vpp-case.drm
+
 * Wed Apr 29 2026 Lishan Liu <lishan.liu@intel.com> - 6.18.20-1
 - Update kernel to 6.18.20-1
 - lts-v6.18.20-emt-cve-260417T093242Z

--- a/SPECS/nvidia-data-center-driver/nvidia-data-center-driver.spec
+++ b/SPECS/nvidia-data-center-driver/nvidia-data-center-driver.spec
@@ -10,7 +10,7 @@
 Summary:        nvidia gpu driver kernel module for data center devices
 Name:           nvidia-data-center-driver
 Version:        580.105.08
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        Public Domain
 Source0:        https://us.download.nvidia.com/tesla/%{version}/NVIDIA-Linux-x86_64-%{version}.run
 Vendor:         Intel Corporation
@@ -51,6 +51,9 @@ make INSTALL_MOD_PATH=%{buildroot} modules_install
 /sbin/depmod -a
 
 %changelog
+* Wed May 13 2026 Lishan Liu <lishan.liu@intel.com> - 580.105.08-8
+- Bump release version for rebuild
+
 * Wed Apr 29 2026 Lishan Liu <lishan.liu@intel.com> - 580.105.08-7
 - Bump release to rebuild
 

--- a/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
+++ b/toolkit/resources/manifests/package/pkggen_core_x86_64.txt
@@ -1,5 +1,5 @@
 filesystem-1.1-21.emt26.x86_64.rpm
-kernel-headers-6.18.20-1.emt26.noarch.rpm
+kernel-headers-6.18.20-2.emt26.noarch.rpm
 glibc-2.38-18.emt26.x86_64.rpm
 glibc-devel-2.38-18.emt26.x86_64.rpm
 glibc-i18n-2.38-18.emt26.x86_64.rpm

--- a/toolkit/resources/manifests/package/toolchain_x86_64.txt
+++ b/toolkit/resources/manifests/package/toolchain_x86_64.txt
@@ -151,8 +151,8 @@ intltool-0.51.0-7.emt26.noarch.rpm
 itstool-2.0.7-1.emt26.noarch.rpm
 kbd-2.2.0-2.emt26.x86_64.rpm
 kbd-debuginfo-2.2.0-2.emt26.x86_64.rpm
-kernel-cross-headers-6.18.20-1.emt26.noarch.rpm
-kernel-headers-6.18.20-1.emt26.noarch.rpm
+kernel-cross-headers-6.18.20-2.emt26.noarch.rpm
+kernel-headers-6.18.20-2.emt26.noarch.rpm
 kmod-30-1.emt26.x86_64.rpm
 kmod-debuginfo-30-1.emt26.x86_64.rpm
 kmod-devel-30-1.emt26.x86_64.rpm


### PR DESCRIPTION
remove patch 0068-drm-i915-no-waiting-for-page-flip-in-vpp-case.drm as it will cause duplicate entry in systctl and lead to docker run failure

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [x] The changes in the PR have been built and tested
- [] cgmanifest file has been updated if required
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Test team has verified that the issue has been resolved with the change
