### PR TITLE
upgrade rpc version to v2.50.4

### DIFF
--- a/SPECS/rpc/rpc.signatures.json
+++ b/SPECS/rpc/rpc.signatures.json
@@ -1,6 +1,6 @@
 {
   "Signatures": {
-    "rpc-go-2.48.14.tar.gz": "78c78b7c8a4827991b2dfd407d8bc0fe32d131ced9962028a2330609b461024e",
-    "rpc-2.48.14-vendor.tar.gz": "dbc47432cb483eafc9f02f894b825a86dadd4f87db327a35c6e12ffa50411016"
+    "rpc-go-2.50.4.tar.gz": "78219fe52fbc50cf688e97387cafbb1cf3940da37f490bfcd32a255b6f451360",
+    "rpc-2.50.4-vendor.tar.gz": "6105f5f0d63cc36dae40d4bcfc95b5f161ef1da8ec83acdadbc48e1d46bdc5e0"
   }
 }

--- a/SPECS/rpc/rpc.spec
+++ b/SPECS/rpc/rpc.spec
@@ -1,14 +1,14 @@
 Summary:        Remote Provisioning Client for Intel AMT
 Name:           rpc
-Version:        2.48.14
-Release:        2%{?dist}
+Version:        2.50.4
+Release:        1%{?dist}
 License:        Apache-2.0
 Vendor:         Intel Corporation
 Distribution:   Edge Microvisor Toolkit
 URL:            https://github.com/device-management-toolkit/rpc-go
 Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-go-%{version}.tar.gz
 Source1:        %{name}-%{version}-vendor.tar.gz
-BuildRequires:  golang >= 1.25.7
+BuildRequires:  golang >= 1.25.9
 %global modulename      rpc
 
 %description
@@ -48,10 +48,13 @@ cp LICENSE %{buildroot}%{_defaultlicensedir}/%{name}
 %license %{_defaultlicensedir}/%{name}/LICENSE
 
 %changelog
+* Tue May 12 2026 Rajesh1X Shanmugam <rajesh1x.shanmugam@intel.com> - 2.50.4-1
+- Upgrade rpc version and golang version
+
 * Tue Feb 24 2026 Andy <andy.peng@intel.com> - 2.48.14-2
 - Upgrade golang version to use 1.25.7
 
-* Thu Jan 21 2026 Polmoorx shiva kumar <polmoorx.shiva.kumar@intel.com> - 2.48.14-1
+* Wed Jan 21 2026 Polmoorx shiva kumar <polmoorx.shiva.kumar@intel.com> - 2.48.14-1
 - Upgraded the RPC version from from 2.48.9 to 2.48.14
 - fixes CVE-2025-61727, CVE-2025-61729
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -13954,8 +13954,8 @@
         "type": "other",
         "other": {
           "name": "rpc",
-          "version": "2.48.14",
-          "downloadUrl": "https://github.com/device-management-toolkit/rpc-go/archive/refs/tags/v2.48.14.tar.gz"
+          "version": "2.50.4",
+          "downloadUrl": "https://github.com/device-management-toolkit/rpc-go/archive/refs/tags/v2.50.4.tar.gz"
         }
       }
     },


### PR DESCRIPTION
Upgrade version to fix CVEs.
Fix CVE-2026-27143, CVE-2026-25679, CVE-2026-27140, CVE-2026-27144, CVE-2026-32280, CVE-2026-32281, CVE-2026-32283, CVE-2026-27142, CVE-2026-32282, CVE-2026-32288, CVE-2026-32289, CVE-2026-27139

#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [X] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List any dependencies that are required for this change. -->
Upgrade rpc version to v2.50.4.
Fixes all CVE's reported against rpc component.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
As part of 3.0-dev PR,
https://cje-ba-prod01.devtools.intel.com/ccg-ecg-tiberos/job/Image_Build/job/On-Demand_Developer_Build/1878/consoleFull