### PR TITLE
[DOCS] Add GH link block in index.md for the OEP website

### DIFF
--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -1,5 +1,16 @@
 # Edge Microvisor Toolkit Documentation
 
+<!--hide_directive
+<div class="component_card_widget">
+  <a class="icon_github" href="https://github.com/open-edge-platform/edge-microvisor-toolkit/tree/26.06-dev">
+     GitHub
+  </a>
+  <a class="icon_document" href="https://github.com/open-edge-platform/edge-microvisor-toolkit/blob/26.06-dev/README.md">
+     Readme
+  </a>
+</div>
+hide_directive-->
+
 Edge Microvisor Toolkit is a reference Linux operating system that demonstrates the full capabilities of Intel processors for Edge AI workloads through Linux patches from Intel that are yet to be upstreamed. The Linux patches optimize performance and other capabilities for Intel silicon -- a result that streamlines integration for operating system vendors and other technology partners.
 
 The toolkit's immutable and mutable versions -- including a standalone node prepared for partner evaluation and a real-time developer node designed with the Preempt RT Linux Kernel for predictable performance -- results in a


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->
**All** boxes should be checked before merging the PR
- [X] The changes in the PR have been built and tested
- [X] cgmanifest file has been updated if required
- [X] Ready to merge

#### Description <!-- REQUIRED -->

Restores an OEP style GH link block to `index.md` to support moving from the live docs on the OEP website to GH.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested? <!-- REQUIRED -->

Links checked, docs built locally.
